### PR TITLE
Add methods for staking

### DIFF
--- a/src/features/stake/StakeForm.tsx
+++ b/src/features/stake/StakeForm.tsx
@@ -66,9 +66,9 @@ interface FormInputProps {
 const StakeFormInputs = (props: FormInputProps) => {
   const { balance } = props;
   const { values, setFieldValue } = useFormikContext<StakeFormValues>();
-  const { estDepositValue } = useEstimations();
-  const value = values.amount && estDepositValue(values.amount);
-  const estimatedRate: number = estDepositValue(1);
+  const { estimateDepositValue } = useEstimations();
+  const value = values.amount && estimateDepositValue(values.amount);
+  const estimatedRate: number = estimateDepositValue(1);
   const roundedBalance = fromWeiRounded(fromWei(balance));
 
   const onClickUseDecimalFraction = (decimalFraction: number) => () => {

--- a/src/features/stake/useEstimations.ts
+++ b/src/features/stake/useEstimations.ts
@@ -2,13 +2,13 @@ import { useCelo } from '@celo/react-celo';
 import BigNumber from 'bignumber.js';
 import { useContracts } from 'src/hooks/useContracts';
 
-const estDepositValue = (amount: number) => amount * 1.03;
+const estimateDepositValue = (amount: number) => amount * 1.03;
 
 export function useEstimations() {
   const { address } = useCelo();
   const { managerContract } = useContracts();
 
-  const estStCELO = async (celoAmount: BigNumber) => {
+  const estimateStCELO = async (celoAmount: BigNumber) => {
     const stCELOAmount = await managerContract.methods
       .toStakedCelo(celoAmount.toString())
       .call({ from: address });
@@ -16,7 +16,7 @@ export function useEstimations() {
   };
 
   return {
-    estStCELO,
-    estDepositValue,
+    estimateStCELO,
+    estimateDepositValue,
   };
 }

--- a/src/features/stake/useEstimations.ts
+++ b/src/features/stake/useEstimations.ts
@@ -1,22 +1,7 @@
-import { useCelo } from '@celo/react-celo';
-import BigNumber from 'bignumber.js';
-import { useContracts } from 'src/hooks/useContracts';
-
 const estimateDepositValue = (amount: number) => amount * 1.03;
 
 export function useEstimations() {
-  const { address } = useCelo();
-  const { managerContract } = useContracts();
-
-  const estimateStCELO = async (celoAmount: BigNumber) => {
-    const stCELOAmount = await managerContract.methods
-      .toStakedCelo(celoAmount.toString())
-      .call({ from: address });
-    return stCELOAmount;
-  };
-
   return {
-    estimateStCELO,
     estimateDepositValue,
   };
 }

--- a/src/features/stake/useStaking.ts
+++ b/src/features/stake/useStaking.ts
@@ -20,8 +20,12 @@ export function useStaking() {
     return estimatedFee.plus(estimatedFee.dividedBy(10));
   };
 
+  const estimateStakedCeloDeposit = async (celoAmount: BigNumber) =>
+    managerContract.methods.toStakedCelo(celoAmount.toString()).call({ from: address });
+
   return {
     stake,
     estimateStakingFee,
+    estimateStakedCeloDeposit,
   };
 }

--- a/src/features/stake/useStaking.ts
+++ b/src/features/stake/useStaking.ts
@@ -1,0 +1,19 @@
+import { useCelo } from '@celo/react-celo';
+import BigNumber from 'bignumber.js';
+import { useContracts } from 'src/hooks/useContracts';
+
+export function useStaking() {
+  const { address } = useCelo();
+  const { managerContract } = useContracts();
+
+  const stake = async (celoAmount: BigNumber) => {
+    await managerContract.methods.deposit().send({
+      from: address,
+      value: celoAmount.toString(),
+    });
+  };
+
+  return {
+    stake,
+  };
+}

--- a/src/features/stake/useStaking.ts
+++ b/src/features/stake/useStaking.ts
@@ -6,14 +6,22 @@ export function useStaking() {
   const { address } = useCelo();
   const { managerContract } = useContracts();
 
-  const stake = async (celoAmount: BigNumber) => {
-    await managerContract.methods.deposit().send({
-      from: address,
-      value: celoAmount.toString(),
-    });
+  const createTxOptions = (celoAmount: BigNumber) => ({
+    from: address,
+    value: celoAmount.toString(),
+  });
+
+  const deposit = () => managerContract.methods.deposit();
+
+  const stake = (celoAmount: BigNumber) => deposit().send(createTxOptions(celoAmount));
+
+  const estimateStakingFee = async (celoAmount: BigNumber): Promise<BigNumber> => {
+    const estimatedFee = new BigNumber(await deposit().estimateGas(createTxOptions(celoAmount)));
+    return estimatedFee.plus(estimatedFee.dividedBy(10));
   };
 
   return {
     stake,
+    estimateStakingFee,
   };
 }


### PR DESCRIPTION
- Removes `estStCELO` method from `useEstimations` - it looks much better in `useStaking` renamed as `estimateStakedCeloDeposit` ❤️ 
- Adds methods to `useStaking` hooks for staking and gas estimation