### PR TITLE
Integrate Celo staking into UI

### DIFF
--- a/src/features/stake/CostsSummary.tsx
+++ b/src/features/stake/CostsSummary.tsx
@@ -1,47 +1,47 @@
 import Image from 'next/image';
 import { useState } from 'react';
 import { Modal } from 'src/components/modals/Modal';
-import { Fee } from 'src/features/stake/types';
+import { Cost } from 'src/features/stake/types';
 import Info from 'src/images/icons/info.svg';
 
-interface FeesSummaryProps {
-  fees: Fee[];
+interface CostsSummaryProps {
+  costs: Cost[];
 }
 
-export const FeesSummary = (props: FeesSummaryProps) => (
+export const CostsSummary = (props: CostsSummaryProps) => (
   <ul className="mx-2 mt-5">
-    {props.fees.map((fee) => (
-      <FeeItem fee={fee} key={fee.title} />
+    {props.costs.map((cost) => (
+      <CostItem cost={cost} key={cost.title} />
     ))}
   </ul>
 );
 
-interface FeeItemProps {
-  fee: Fee;
+interface CostItemProps {
+  cost: Cost;
 }
 
-const FeeItem = (props: FeeItemProps) => {
-  const { fee } = props;
+const CostItem = (props: CostItemProps) => {
+  const { cost } = props;
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <li key={fee.title} className="flex justify-between my-2 text-gray-400">
+    <li key={cost.title} className="flex justify-between my-2 text-gray-400">
       <span className="flex">
-        {fee.title}
+        {cost.title}
         <span className="flex align-middle ml-2">
           <Image
             className="cursor-pointer"
             src={Info}
-            alt={`${fee.title} fee info`}
+            alt={`${cost.title} cost info`}
             height={20}
             width={20}
             onClick={() => setIsOpen(true)}
           />
         </span>
       </span>
-      <span className={fee.value === 'Free' ? 'text-green' : ''}>{fee.value}</span>
+      <span className={cost.value === 'Free' ? 'text-green' : ''}>{cost.value}</span>
       <Modal isOpen={isOpen} close={() => setIsOpen(false)}>
-        {fee.tooltip.content}
+        {cost.tooltip.content}
       </Modal>
     </li>
   );

--- a/src/features/stake/ReceiveSummary.tsx
+++ b/src/features/stake/ReceiveSummary.tsx
@@ -6,16 +6,17 @@ interface ReceiveSummaryProps {
   amount: number | undefined;
 }
 
-export const ReceiveSummary = (props: ReceiveSummaryProps) => {
+export const ReceiveSummary = ({ amount }: ReceiveSummaryProps) => {
   const { estimateDepositValue } = useEstimations();
-  const value = props.amount && estimateDepositValue(props.amount);
+  const estimatedValue = amount && estimateDepositValue(amount);
+  const displayValue = estimatedValue ? estimatedValue.toFixed(DISPLAY_DECIMALS) : 0.0;
 
   return (
     <TokenCard
       classes="w-full"
       token="stCELO"
       titleChild="Receive"
-      inputChild={value ? value.toFixed(DISPLAY_DECIMALS) : 0.0}
+      inputChild={displayValue}
       infoChild={<span className="text-pear">4.56% projected APY</span>}
     />
   );

--- a/src/features/stake/Stake.tsx
+++ b/src/features/stake/Stake.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { FloatingBox } from 'src/components/containers/FloatingBox';
-import { FeesSummary } from 'src/features/stake/FeesSummary';
+import { CostsSummary } from 'src/features/stake/CostsSummary';
 import { TokenCard } from 'src/features/stake/FormTemplate';
 import { ReceiveSummary } from 'src/features/stake/ReceiveSummary';
 import { fromWeiRounded } from 'src/formatters/amount';
@@ -13,37 +13,12 @@ import Arrow from 'src/images/icons/arrow.svg';
 import { BalanceTools } from './BalanceTools';
 import { SubmitButton } from './SubmitButton';
 import { StakeFormValues } from './types';
+import { useCosts } from './useCosts';
 import { useFormValidator } from './useFormValidator';
 
 const initialValues: StakeFormValues = {
   amount: '' as unknown as number,
 };
-
-const fees = [
-  {
-    title: 'Exchange Rate',
-    value: 1.03,
-    tooltip: {
-      content:
-        'stCELO’s exchange rate continuously accrues value vs CELO. As you receive rewards, your amount of stCELO will not change but when you unstake it will be worth more CELO than what you paid.',
-    },
-  },
-  {
-    title: 'Transaction Cost',
-    value: '< $0.01',
-    tooltip: {
-      content:
-        'Every blockchain transaction requires gas fees to be paid. The amount mentioned is an estimate of these gas costs.',
-    },
-  },
-  {
-    title: 'Fees',
-    value: 'Free',
-    tooltip: {
-      content: 'For the launch of the stCELO protocol, fees are free.',
-    },
-  },
-];
 
 export const Stake = () => {
   const onSubmit = (values: StakeFormValues) => {
@@ -65,6 +40,7 @@ interface StakeFormProps {
 export const StakeForm = ({ onSubmit }: StakeFormProps) => {
   const [amount, setAmount] = useState<number | undefined>(0);
   const { address, celoBalance } = useAccount();
+  const { costs } = useCosts(amount);
   const validateForm = useFormValidator();
 
   return (
@@ -93,7 +69,7 @@ export const StakeForm = ({ onSubmit }: StakeFormProps) => {
           <SubmitButton color={'purple'} address={address} />
         </div>
 
-        <FeesSummary fees={fees} />
+        <CostsSummary costs={costs} />
       </Form>
     </Formik>
   );

--- a/src/features/stake/Stake.tsx
+++ b/src/features/stake/Stake.tsx
@@ -7,7 +7,8 @@ import { FloatingBox } from 'src/components/containers/FloatingBox';
 import { CostsSummary } from 'src/features/stake/CostsSummary';
 import { TokenCard } from 'src/features/stake/FormTemplate';
 import { ReceiveSummary } from 'src/features/stake/ReceiveSummary';
-import { fromWeiRounded } from 'src/formatters/amount';
+import { useStaking } from 'src/features/stake/useStaking';
+import { fromWeiRounded, toWei } from 'src/formatters/amount';
 import { useAccount } from 'src/hooks/useAccount';
 import Arrow from 'src/images/icons/arrow.svg';
 import { BalanceTools } from './BalanceTools';
@@ -21,9 +22,10 @@ const initialValues: StakeFormValues = {
 };
 
 export const Stake = () => {
-  const onSubmit = (values: StakeFormValues) => {
-    // eslint-disable-next-line no-console
-    console.log(values);
+  const { stake } = useStaking();
+  const onSubmit = async ({ amount }: StakeFormValues) => {
+    if (!amount) return;
+    await stake(toWei(new BigNumber(amount)));
   };
 
   return (

--- a/src/features/stake/Stake.tsx
+++ b/src/features/stake/Stake.tsx
@@ -1,4 +1,3 @@
-import BigNumber from 'bignumber.js';
 import { Field, Form, Formik, useFormikContext } from 'formik';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -8,9 +7,10 @@ import { CostsSummary } from 'src/features/stake/CostsSummary';
 import { TokenCard } from 'src/features/stake/FormTemplate';
 import { ReceiveSummary } from 'src/features/stake/ReceiveSummary';
 import { useStaking } from 'src/features/stake/useStaking';
-import { fromWeiRounded, toWei } from 'src/formatters/amount';
+import { fromWeiRounded, toCeloWei } from 'src/formatters/amount';
 import { useAccount } from 'src/hooks/useAccount';
 import Arrow from 'src/images/icons/arrow.svg';
+import { Celo, CeloWei } from 'src/types/units';
 import { BalanceTools } from './BalanceTools';
 import { SubmitButton } from './SubmitButton';
 import { StakeFormValues } from './types';
@@ -25,7 +25,7 @@ export const Stake = () => {
   const { stake } = useStaking();
   const onSubmit = async ({ amount }: StakeFormValues) => {
     if (!amount) return;
-    await stake(toWei(new BigNumber(amount)));
+    await stake(toCeloWei(new Celo(amount)));
   };
 
   return (
@@ -78,7 +78,7 @@ export const StakeForm = ({ onSubmit }: StakeFormProps) => {
 };
 
 interface FormInputProps {
-  balance: BigNumber;
+  balance: CeloWei;
   onChange: (amount: number | undefined) => void;
 }
 

--- a/src/features/stake/Stake.tsx
+++ b/src/features/stake/Stake.tsx
@@ -68,7 +68,7 @@ export const StakeForm = ({ onSubmit }: StakeFormProps) => {
         </FloatingBox>
 
         <div className="flex justify-center mt-5 mb-1">
-          <SubmitButton color={'purple'} address={address} />
+          <SubmitButton color="purple" address={address || ''} />
         </div>
 
         <CostsSummary costs={costs} />

--- a/src/features/stake/SubmitButton.tsx
+++ b/src/features/stake/SubmitButton.tsx
@@ -5,7 +5,7 @@ import { useTimeout } from 'src/hooks/useTimeout';
 import { StakeFormValues } from './types';
 
 interface ButtonProps {
-  address?: string;
+  address: string;
   color: 'purple' | 'orange';
 }
 

--- a/src/features/stake/types.ts
+++ b/src/features/stake/types.ts
@@ -2,7 +2,7 @@ export interface StakeFormValues {
   amount?: number;
 }
 
-export interface Fee {
+export interface Cost {
   title: string;
   value: string | number;
   tooltip: {

--- a/src/features/stake/useCosts.ts
+++ b/src/features/stake/useCosts.ts
@@ -1,0 +1,70 @@
+import BigNumber from 'bignumber.js';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { DISPLAY_DECIMALS } from 'src/config/consts';
+import { fromWei, toWei } from 'src/formatters/amount';
+import { useExchangeRates } from 'src/hooks/useExchangeRates';
+import { Cost } from './types';
+import { useStaking } from './useStaking';
+
+const exchangeCost: Cost = {
+  title: 'Exchange Rate',
+  value: '...',
+  tooltip: {
+    content:
+      'stCELO’s exchange rate continuously accrues value vs CELO. As you receive rewards, your amount of stCELO will not change but when you unstake it will be worth more CELO than what you paid.',
+  },
+};
+
+const transactionCost: Cost = {
+  title: 'Transaction Cost',
+  value: '...',
+  tooltip: {
+    content:
+      'Every blockchain transaction requires gas fees to be paid. The amount mentioned is an estimate of these gas costs.',
+  },
+};
+
+const feeCost: Cost = {
+  title: 'Fees',
+  value: 'Free',
+  tooltip: {
+    content: 'For the launch of the stCELO protocol, fees are free.',
+  },
+};
+
+export const useCosts = (amount: number | undefined) => {
+  const { celoExchangeRate } = useExchangeRates();
+  const { estimateGasFee } = useStaking();
+
+  const [gasFee, setGasFee] = useState(new BigNumber(0));
+
+  const calculateGasFee = useCallback(async () => {
+    if (!amount) return;
+    const gasFee = await estimateGasFee(toWei(new BigNumber(amount)));
+    setGasFee(fromWei(gasFee));
+  }, [estimateGasFee, amount]);
+
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    calculateGasFee();
+  }, [calculateGasFee]);
+
+  const calculatedCosts = useMemo(
+    () => [
+      {
+        ...exchangeCost,
+        value: celoExchangeRate ? celoExchangeRate.toFixed(DISPLAY_DECIMALS) : '...',
+      },
+      {
+        ...transactionCost,
+        value: gasFee.comparedTo(0.001) === -1 ? '< 0.001' : `~${gasFee.toFixed(DISPLAY_DECIMALS)}`,
+      },
+      feeCost,
+    ],
+    [celoExchangeRate, gasFee]
+  );
+
+  return {
+    costs: calculatedCosts,
+  };
+};

--- a/src/features/stake/useCosts.ts
+++ b/src/features/stake/useCosts.ts
@@ -1,8 +1,8 @@
-import BigNumber from 'bignumber.js';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { DISPLAY_DECIMALS } from 'src/config/consts';
-import { fromWei, toWei } from 'src/formatters/amount';
+import { fromCeloWei, toCeloWei } from 'src/formatters/amount';
 import { useExchangeRates } from 'src/hooks/useExchangeRates';
+import { Celo } from 'src/types/units';
 import { Cost } from './types';
 import { useStaking } from './useStaking';
 
@@ -36,12 +36,12 @@ export const useCosts = (amount: number | undefined) => {
   const { celoExchangeRate } = useExchangeRates();
   const { estimateGasFee } = useStaking();
 
-  const [gasFee, setGasFee] = useState(new BigNumber(0));
+  const [gasFee, setGasFee] = useState(new Celo(0));
 
   const calculateGasFee = useCallback(async () => {
     if (!amount) return;
-    const gasFee = await estimateGasFee(toWei(new BigNumber(amount)));
-    setGasFee(fromWei(gasFee));
+    const estimatedGasFee = await estimateGasFee(toCeloWei(new Celo(amount)));
+    setGasFee(fromCeloWei(estimatedGasFee));
   }, [estimateGasFee, amount]);
 
   useEffect(() => {

--- a/src/features/stake/useEstimations.ts
+++ b/src/features/stake/useEstimations.ts
@@ -1,6 +1,14 @@
-const estimateDepositValue = (amount: number) => amount * 1.03;
+import { useCallback } from 'react';
+import { useExchangeRates } from 'src/hooks/useExchangeRates';
 
 export function useEstimations() {
+  const { celoExchangeRate } = useExchangeRates();
+
+  const estimateDepositValue = useCallback(
+    (amount: number) => amount * celoExchangeRate,
+    [celoExchangeRate]
+  );
+
   return {
     estimateDepositValue,
   };

--- a/src/features/stake/useStaking.ts
+++ b/src/features/stake/useStaking.ts
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useState } from 'react';
 import { toWei } from 'src/formatters/amount';
 import { useAccount } from 'src/hooks/useAccount';
 import { useContracts } from 'src/hooks/useContracts';
-import logger from 'src/services/logger';
 
 export function useStaking() {
   const { address, loadBalances } = useAccount();
@@ -46,7 +45,8 @@ export function useStaking() {
   }, [managerContract, address]);
 
   useEffect(() => {
-    loadExchangeRate().catch((error: any) => logger.error(error?.message));
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    loadExchangeRate();
   }, [loadExchangeRate]);
 
   return {

--- a/src/features/stake/useStaking.ts
+++ b/src/features/stake/useStaking.ts
@@ -1,6 +1,5 @@
 import BigNumber from 'bignumber.js';
-import { useCallback, useEffect, useState } from 'react';
-import { toWei } from 'src/formatters/amount';
+import { useCallback, useState } from 'react';
 import { useAccount } from 'src/hooks/useAccount';
 import { useContracts } from 'src/hooks/useContracts';
 
@@ -37,25 +36,9 @@ export function useStaking() {
     [createTxOptions, deposit]
   );
 
-  const [exchangeRate, setExchangeRate] = useState(0);
-
-  const loadExchangeRate = useCallback(async () => {
-    const oneCeloInWei = toWei(new BigNumber('1'));
-    const stakedCeloAmount = new BigNumber(
-      await managerContract.methods.toStakedCelo(oneCeloInWei).call({ from: address })
-    );
-    setExchangeRate(stakedCeloAmount.dividedBy(oneCeloInWei).toNumber());
-  }, [managerContract, address]);
-
-  useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    loadExchangeRate();
-  }, [loadExchangeRate]);
-
   return {
     stake,
     isStaking,
     estimateFee,
-    exchangeRate,
   };
 }

--- a/src/features/stake/useStaking.ts
+++ b/src/features/stake/useStaking.ts
@@ -28,10 +28,10 @@ export function useStaking() {
     [createTxOptions, deposit, loadBalances]
   );
 
-  const estimateFee = useCallback(
+  const estimateGasFee = useCallback(
     async (celoAmount: BigNumber): Promise<BigNumber> => {
-      const estimatedFee = new BigNumber(await deposit().estimateGas(createTxOptions(celoAmount)));
-      return estimatedFee.plus(estimatedFee.dividedBy(10));
+      const gasFee = new BigNumber(await deposit().estimateGas(createTxOptions(celoAmount)));
+      return gasFee.plus(gasFee.dividedBy(10));
     },
     [createTxOptions, deposit]
   );
@@ -39,6 +39,6 @@ export function useStaking() {
   return {
     stake,
     isStaking,
-    estimateFee,
+    estimateGasFee,
   };
 }

--- a/src/features/stake/useStaking.ts
+++ b/src/features/stake/useStaking.ts
@@ -1,16 +1,16 @@
-import BigNumber from 'bignumber.js';
 import { useCallback, useState } from 'react';
 import { useAccount } from 'src/hooks/useAccount';
 import { useContracts } from 'src/hooks/useContracts';
+import { CeloWei } from 'src/types/units';
 
 export function useStaking() {
   const { address, loadBalances } = useAccount();
   const { managerContract } = useContracts();
 
   const createTxOptions = useCallback(
-    (celoAmount: BigNumber) => ({
+    (amount: CeloWei) => ({
       from: address,
-      value: celoAmount.toString(),
+      value: amount.toString(),
     }),
     [address]
   );
@@ -19,9 +19,9 @@ export function useStaking() {
 
   const [isStaking, setIsStaking] = useState(false);
   const stake = useCallback(
-    async (celoAmount: BigNumber) => {
+    async (amount: CeloWei) => {
       setIsStaking(true);
-      await deposit().send(createTxOptions(celoAmount));
+      await deposit().send(createTxOptions(amount));
       await loadBalances();
       setIsStaking(false);
     },
@@ -29,9 +29,10 @@ export function useStaking() {
   );
 
   const estimateGasFee = useCallback(
-    async (celoAmount: BigNumber): Promise<BigNumber> => {
-      const gasFee = new BigNumber(await deposit().estimateGas(createTxOptions(celoAmount)));
-      return gasFee.plus(gasFee.dividedBy(10));
+    async (amount: CeloWei): Promise<CeloWei> => {
+      const gasFee = new CeloWei(await deposit().estimateGas(createTxOptions(amount)));
+      const increasedGasFee = gasFee.plus(gasFee.dividedBy(10)).toString();
+      return new CeloWei(increasedGasFee);
     },
     [createTxOptions, deposit]
   );

--- a/src/features/stake/useStaking.ts
+++ b/src/features/stake/useStaking.ts
@@ -18,10 +18,13 @@ export function useStaking() {
 
   const deposit = useCallback(() => managerContract.methods.deposit(), [managerContract]);
 
+  const [isStaking, setIsStaking] = useState(false);
   const stake = useCallback(
     async (celoAmount: BigNumber) => {
+      setIsStaking(true);
       await deposit().send(createTxOptions(celoAmount));
       await loadBalances();
+      setIsStaking(false);
     },
     [createTxOptions, deposit, loadBalances]
   );
@@ -51,6 +54,7 @@ export function useStaking() {
 
   return {
     stake,
+    isStaking,
     estimateFee,
     exchangeRate,
   };

--- a/src/formatters/amount.ts
+++ b/src/formatters/amount.ts
@@ -1,21 +1,27 @@
 import BigNumber from 'bignumber.js';
 import { MIN_ROUNDED_VALUE, WEI_PER_UNIT } from 'src/config/consts';
+import { Celo, CeloWei, StakedCelo, StakedCeloWei } from 'src/types/units';
 import { fromWei as web3FromWei, toWei as web3ToWei } from 'web3-utils';
 
-export function fromWei(value: BigNumber | null | undefined): BigNumber {
-  if (!value) return new BigNumber(0);
-  const flooredValue = new BigNumber(value).toFixed(0, BigNumber.ROUND_FLOOR);
-  return new BigNumber(web3FromWei(flooredValue));
+function fromWei(value: BigNumber): string {
+  if (!value) return '0';
+  const flooredValue = value.toFixed(0, BigNumber.ROUND_FLOOR);
+  return web3FromWei(flooredValue);
+}
+
+export function fromCeloWei(value: CeloWei): Celo {
+  return new Celo(fromWei(value));
+}
+
+export function fromStakedCeloWei(value: StakedCeloWei): StakedCelo {
+  return new StakedCelo(fromWei(value));
 }
 
 // Similar to fromWei above but rounds to set number of decimals
 // with a minimum floor, configured per token
-export function fromWeiRounded(
-  value: BigNumber | null | undefined,
-  roundToZeroIfSmall = false
-): number {
+export function fromWeiRounded(value: CeloWei | StakedCeloWei, roundToZeroIfSmall = false): number {
   if (!value) return 0;
-  const flooredValue = new BigNumber(value).toFixed(0, BigNumber.ROUND_FLOOR);
+  const flooredValue = value.toFixed(0, BigNumber.ROUND_FLOOR);
   const amount = new BigNumber(web3FromWei(flooredValue));
   if (amount.isZero()) return 0;
 
@@ -28,16 +34,24 @@ export function fromWeiRounded(
   return amount.toNumber();
 }
 
-export function toWei(value: BigNumber | null | undefined): BigNumber {
-  if (!value) return new BigNumber(0);
+function toWei(value: BigNumber): string {
+  if (!value) return '0';
   const valueString = value.toString();
   const components = valueString.split('.');
   if (components.length === 1) {
-    return new BigNumber(web3ToWei(value.toString()));
+    return web3ToWei(value.toString());
   } else if (components.length === 2) {
     const trimmedFraction = components[1].substring(0, WEI_PER_UNIT.length - 1);
-    return new BigNumber(web3ToWei(`${components[0]}.${trimmedFraction}`));
+    return web3ToWei(`${components[0]}.${trimmedFraction}`);
   } else {
     throw new Error(`Cannot convert ${valueString} to wei`);
   }
+}
+
+export function toCeloWei(value: Celo): CeloWei {
+  return new CeloWei(toWei(value));
+}
+
+export function toStakedCeloWei(value: StakedCelo): StakedCeloWei {
+  return new StakedCeloWei(toWei(value));
 }

--- a/src/hooks/useExchangeRates.ts
+++ b/src/hooks/useExchangeRates.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { ExchangeContext } from 'src/providers/ExchangeProvider';
+
+export function useExchangeRates() {
+  const { celoExchangeRate, stakedCeloExchangeRate } = useContext(ExchangeContext);
+
+  return {
+    celoExchangeRate,
+    stakedCeloExchangeRate,
+  };
+}

--- a/src/providers/AccountProvider.tsx
+++ b/src/providers/AccountProvider.tsx
@@ -2,7 +2,6 @@ import { useCelo } from '@celo/react-celo';
 import BigNumber from 'bignumber.js';
 import { createContext, PropsWithChildren, useCallback, useEffect, useState } from 'react';
 import { useContracts } from 'src/hooks/useContracts';
-import logger from 'src/services/logger';
 
 interface IAccountContext {
   isConnected: boolean;
@@ -48,7 +47,8 @@ const useBalances = () => {
   }, [loadCeloBalance, loadStakedCeloBalance]);
 
   useEffect(() => {
-    loadBalances().catch((error: any) => logger.error(error?.message));
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    loadBalances();
   }, [loadBalances]);
 
   return {

--- a/src/providers/AccountProvider.tsx
+++ b/src/providers/AccountProvider.tsx
@@ -1,13 +1,13 @@
 import { useCelo } from '@celo/react-celo';
-import BigNumber from 'bignumber.js';
 import { createContext, PropsWithChildren, useCallback, useEffect, useState } from 'react';
 import { useContracts } from 'src/hooks/useContracts';
+import { CeloWei, StakedCeloWei } from 'src/types/units';
 
 interface IAccountContext {
   isConnected: boolean;
   address: string | undefined | null;
-  celoBalance: BigNumber;
-  stakedCeloBalance: BigNumber;
+  celoBalance: CeloWei;
+  stakedCeloBalance: StakedCeloWei;
   loadBalances: () => Promise<void>;
 }
 
@@ -23,8 +23,8 @@ const useBalances = () => {
   const { address } = useAddress();
   const { stakedCeloContract } = useContracts();
 
-  const [celoBalance, setCeloBalance] = useState(new BigNumber(0));
-  const [stakedCeloBalance, setStakedCeloBalance] = useState(new BigNumber(0));
+  const [celoBalance, setCeloBalance] = useState(new CeloWei(0));
+  const [stakedCeloBalance, setStakedCeloBalance] = useState(new StakedCeloWei(0));
 
   const loadCeloBalance = useCallback(async () => {
     const { eth } = kit.connection.web3;
@@ -32,14 +32,14 @@ const useBalances = () => {
 
     const balance = await eth.getBalance(address);
 
-    setCeloBalance(new BigNumber(balance));
+    setCeloBalance(new CeloWei(balance));
   }, [kit.connection, address]);
 
   const loadStakedCeloBalance = useCallback(async () => {
     const stakedCeloBalance = await stakedCeloContract.methods.balanceOf(address).call({
       from: address,
     });
-    setStakedCeloBalance(new BigNumber(stakedCeloBalance));
+    setStakedCeloBalance(new StakedCeloWei(stakedCeloBalance));
   }, [address, stakedCeloContract]);
 
   const loadBalances = useCallback(async () => {
@@ -61,8 +61,8 @@ const useBalances = () => {
 export const AccountContext = createContext<IAccountContext>({
   isConnected: false,
   address: null,
-  celoBalance: new BigNumber(0),
-  stakedCeloBalance: new BigNumber(0),
+  celoBalance: new CeloWei(0),
+  stakedCeloBalance: new StakedCeloWei(0),
   loadBalances: () => Promise.resolve(),
 });
 

--- a/src/providers/CeloProvider.tsx
+++ b/src/providers/CeloProvider.tsx
@@ -5,6 +5,7 @@ import { PropsWithChildren } from 'react';
 import { networkConfig } from 'src/config/celo';
 import { useAccount } from 'src/hooks/useAccount';
 import { AccountProvider } from './AccountProvider';
+import { ExchangeProvider } from './ExchangeProvider';
 
 export const CeloProvider = (props: PropsWithChildren) => {
   return (
@@ -24,7 +25,9 @@ export const CeloProvider = (props: PropsWithChildren) => {
       }}
     >
       <AccountProvider>
-        <CeloConnectRedirect>{props.children}</CeloConnectRedirect>
+        <ExchangeProvider>
+          <CeloConnectRedirect>{props.children}</CeloConnectRedirect>
+        </ExchangeProvider>
       </AccountProvider>
     </ReactCeloProvider>
   );

--- a/src/providers/ExchangeProvider.tsx
+++ b/src/providers/ExchangeProvider.tsx
@@ -1,0 +1,63 @@
+import BigNumber from 'bignumber.js';
+import { createContext, PropsWithChildren, useCallback, useEffect, useState } from 'react';
+import { toWei } from 'src/formatters/amount';
+import { useAccount } from 'src/hooks/useAccount';
+import { useContracts } from 'src/hooks/useContracts';
+
+interface IExchangeContext {
+  celoExchangeRate: number;
+  stakedCeloExchangeRate: number;
+  loadExchangeRates: () => Promise<void>;
+}
+
+const useExchangeRate = () => {
+  const { address } = useAccount();
+  const { managerContract } = useContracts();
+
+  const [celoExchangeRate, setCeloExchangeRate] = useState(0);
+
+  const loadCeloExchangeRate = useCallback(async () => {
+    const oneCeloInWei = toWei(new BigNumber('1'));
+    const stakedCeloAmount = new BigNumber(
+      await managerContract.methods.toStakedCelo(oneCeloInWei).call({ from: address })
+    );
+    setCeloExchangeRate(stakedCeloAmount.dividedBy(oneCeloInWei).toNumber());
+  }, [managerContract, address]);
+
+  const loadExchangeRates = useCallback(async () => {
+    await Promise.all([loadCeloExchangeRate()]);
+  }, [loadCeloExchangeRate]);
+
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    loadExchangeRates();
+  }, [loadExchangeRates]);
+
+  return {
+    celoExchangeRate,
+    stakedCeloExchangeRate: 0,
+    loadExchangeRates,
+  };
+};
+
+export const ExchangeContext = createContext<IExchangeContext>({
+  celoExchangeRate: 0,
+  stakedCeloExchangeRate: 0,
+  loadExchangeRates: () => Promise.resolve(),
+});
+
+export const ExchangeProvider = ({ children }: PropsWithChildren) => {
+  const { celoExchangeRate, stakedCeloExchangeRate, loadExchangeRates } = useExchangeRate();
+
+  return (
+    <ExchangeContext.Provider
+      value={{
+        celoExchangeRate,
+        stakedCeloExchangeRate,
+        loadExchangeRates,
+      }}
+    >
+      {children}
+    </ExchangeContext.Provider>
+  );
+};

--- a/src/providers/ExchangeProvider.tsx
+++ b/src/providers/ExchangeProvider.tsx
@@ -1,8 +1,8 @@
-import BigNumber from 'bignumber.js';
 import { createContext, PropsWithChildren, useCallback, useEffect, useState } from 'react';
-import { toWei } from 'src/formatters/amount';
+import { toCeloWei } from 'src/formatters/amount';
 import { useAccount } from 'src/hooks/useAccount';
 import { useContracts } from 'src/hooks/useContracts';
+import { Celo, StakedCeloWei } from 'src/types/units';
 
 interface IExchangeContext {
   celoExchangeRate: number;
@@ -17,11 +17,11 @@ const useExchangeRate = () => {
   const [celoExchangeRate, setCeloExchangeRate] = useState(0);
 
   const loadCeloExchangeRate = useCallback(async () => {
-    const oneCeloInWei = toWei(new BigNumber('1'));
-    const stakedCeloAmount = new BigNumber(
-      await managerContract.methods.toStakedCelo(oneCeloInWei).call({ from: address })
+    const oneCeloWei = toCeloWei(new Celo('1')).toString();
+    const stakedCeloAmount = new StakedCeloWei(
+      await managerContract.methods.toStakedCelo(oneCeloWei).call({ from: address })
     );
-    setCeloExchangeRate(stakedCeloAmount.dividedBy(oneCeloInWei).toNumber());
+    setCeloExchangeRate(stakedCeloAmount.dividedBy(oneCeloWei).toNumber());
   }, [managerContract, address]);
 
   const loadExchangeRates = useCallback(async () => {

--- a/src/types/units.ts
+++ b/src/types/units.ts
@@ -1,0 +1,17 @@
+import BigNumber from 'bignumber.js';
+
+export class Celo extends BigNumber {
+  private __tokenType = 'Celo';
+}
+
+export class CeloWei extends BigNumber {
+  private __tokenType = 'CeloWei';
+}
+
+export class StakedCelo extends BigNumber {
+  private __tokenType = 'StakedCelo';
+}
+
+export class StakedCeloWei extends BigNumber {
+  private __tokenType = 'StakedCeloWei';
+}


### PR DESCRIPTION
- Add `ExchangeProvider` for globally available exchange rates
- Use actual exchange rate to calculate Celo deposit
- Add actual cost calculation of transaction
- Stake Celo on submit
- Add dedicated types for tokens and units (`Celo`, `CeloWei` etc.)
- Fix TS errors