### PR TITLE
Display total staked Celo amount

### DIFF
--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -9,6 +9,7 @@ import { TokenCard } from 'src/features/swap/FormTemplate';
 import { ReceiveSummary } from 'src/features/swap/ReceiveSummary';
 import { fromWeiRounded } from 'src/formatters/amount';
 import Arrow from 'src/images/icons/arrow.svg';
+import { useExchangeContext } from 'src/providers/ExchangeProvider';
 import { CeloWei, StCeloWei } from 'src/types/units';
 import { BalanceTools } from './BalanceTools';
 import { SubmitButton } from './SubmitButton';
@@ -45,17 +46,19 @@ export const SwapForm = (props: SwapFormProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const { costs } = useCosts(amount, exchangeRate, estimateGasFee);
   const validateForm = useFormValidator(balance, fromToken);
+  const { reloadExchangeContext } = useExchangeContext();
   const submit = useCallback(
     async (formValues: SwapFormValues, { resetForm }: FormikHelpers<SwapFormValues>) => {
       setIsLoading(true);
       try {
         await onSubmit(formValues);
+        await reloadExchangeContext();
       } finally {
         setIsLoading(false);
       }
       resetForm({ values: initialValues });
     },
-    [onSubmit]
+    [onSubmit, reloadExchangeContext]
   );
 
   return (

--- a/src/hooks/useTokensBalances.ts
+++ b/src/hooks/useTokensBalances.ts
@@ -1,0 +1,22 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fromCeloWei } from 'src/formatters/amount';
+import { useContracts } from 'src/hooks/useContracts';
+import { Celo, CeloWei } from 'src/types/units';
+
+export const useTokenBalances = () => {
+  const { accountContract } = useContracts();
+
+  const [totalCeloBalance, setTotalCeloBalance] = useState<Celo>(new Celo(0));
+  const loadTotalCeloBalance = useCallback(async () => {
+    const totalCeloWei = new CeloWei(await accountContract.methods.getTotalCelo().call());
+    setTotalCeloBalance(fromCeloWei(totalCeloWei));
+  }, [accountContract]);
+
+  useEffect(() => {
+    void loadTotalCeloBalance();
+  }, [loadTotalCeloBalance]);
+
+  return {
+    totalCeloBalance,
+  };
+};

--- a/src/hooks/useTokensBalances.ts
+++ b/src/hooks/useTokensBalances.ts
@@ -12,11 +12,16 @@ export const useTokenBalances = () => {
     setTotalCeloBalance(fromCeloWei(totalCeloWei));
   }, [accountContract]);
 
-  useEffect(() => {
-    void loadTotalCeloBalance();
+  const loadTokensBalances = useCallback(async () => {
+    await Promise.all([loadTotalCeloBalance()]);
   }, [loadTotalCeloBalance]);
+
+  useEffect(() => {
+    void loadTokensBalances();
+  }, [loadTokensBalances]);
 
   return {
     totalCeloBalance,
+    loadTokensBalances,
   };
 };

--- a/src/layout/partials/Footer.tsx
+++ b/src/layout/partials/Footer.tsx
@@ -1,15 +1,19 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { DISPLAY_DECIMALS } from 'src/config/consts';
 import Discord from 'src/images/icons/discord.svg';
 import Github from 'src/images/icons/github.svg';
 import Twitter from 'src/images/icons/twitter.svg';
+import { useExchangeContext } from 'src/providers/ExchangeProvider';
 
 export const Footer = () => {
+  const { totalCeloBalance } = useExchangeContext();
+
   return (
     <footer className="w-screen bg-gray-800 text-gray-100 flex flex-col p-7 md:flex-row md:justify-between">
       <div className="mt-2 flex flex-col md:order-first">
         <span className="text-l font-light">Total CELO staked</span>
-        <span className="text-xl">1,234,567.89</span>
+        <span className="text-xl">{totalCeloBalance.toFixed(DISPLAY_DECIMALS)}</span>
       </div>
 
       <ul className="my-4 underline md:order-last">

--- a/src/providers/ExchangeProvider.tsx
+++ b/src/providers/ExchangeProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, PropsWithChildren, useContext } from 'react';
+import { createContext, PropsWithChildren, useCallback, useContext } from 'react';
 import { useExchangeRates } from 'src/hooks/useExchangeRates';
 import { useTokenBalances } from 'src/hooks/useTokensBalances';
 import { Celo } from 'src/types/units';
@@ -7,17 +7,21 @@ interface ExchangeContext {
   celoExchangeRate: number;
   stCeloExchangeRate: number;
   totalCeloBalance: Celo;
+  loadExchangeRates: () => Promise<void>;
+  loadTokensBalances: () => Promise<void>;
 }
 
 export const ExchangeContext = createContext<ExchangeContext>({
   celoExchangeRate: 0,
   stCeloExchangeRate: 0,
   totalCeloBalance: new Celo(0),
+  loadExchangeRates: () => Promise.resolve(),
+  loadTokensBalances: () => Promise.resolve(),
 });
 
 export const ExchangeProvider = ({ children }: PropsWithChildren) => {
-  const { celoExchangeRate, stCeloExchangeRate } = useExchangeRates();
-  const { totalCeloBalance } = useTokenBalances();
+  const { celoExchangeRate, stCeloExchangeRate, loadExchangeRates } = useExchangeRates();
+  const { totalCeloBalance, loadTokensBalances } = useTokenBalances();
 
   return (
     <ExchangeContext.Provider
@@ -25,6 +29,8 @@ export const ExchangeProvider = ({ children }: PropsWithChildren) => {
         celoExchangeRate,
         stCeloExchangeRate,
         totalCeloBalance,
+        loadExchangeRates,
+        loadTokensBalances,
       }}
     >
       {children}
@@ -33,11 +39,22 @@ export const ExchangeProvider = ({ children }: PropsWithChildren) => {
 };
 
 export function useExchangeContext() {
-  const { celoExchangeRate, stCeloExchangeRate, totalCeloBalance } = useContext(ExchangeContext);
+  const {
+    celoExchangeRate,
+    stCeloExchangeRate,
+    totalCeloBalance,
+    loadExchangeRates,
+    loadTokensBalances,
+  } = useContext(ExchangeContext);
+
+  const reloadExchangeContext = useCallback(async () => {
+    await Promise.all([loadExchangeRates(), loadTokensBalances()]);
+  }, [loadExchangeRates, loadTokensBalances]);
 
   return {
     celoExchangeRate,
     stCeloExchangeRate,
     totalCeloBalance,
+    reloadExchangeContext,
   };
 }

--- a/src/providers/ExchangeProvider.tsx
+++ b/src/providers/ExchangeProvider.tsx
@@ -1,24 +1,30 @@
 import { createContext, PropsWithChildren, useContext } from 'react';
 import { useExchangeRates } from 'src/hooks/useExchangeRates';
+import { useTokenBalances } from 'src/hooks/useTokensBalances';
+import { Celo } from 'src/types/units';
 
 interface ExchangeContext {
   celoExchangeRate: number;
   stCeloExchangeRate: number;
+  totalCeloBalance: Celo;
 }
 
 export const ExchangeContext = createContext<ExchangeContext>({
   celoExchangeRate: 0,
   stCeloExchangeRate: 0,
+  totalCeloBalance: new Celo(0),
 });
 
 export const ExchangeProvider = ({ children }: PropsWithChildren) => {
   const { celoExchangeRate, stCeloExchangeRate } = useExchangeRates();
+  const { totalCeloBalance } = useTokenBalances();
 
   return (
     <ExchangeContext.Provider
       value={{
         celoExchangeRate,
         stCeloExchangeRate,
+        totalCeloBalance,
       }}
     >
       {children}
@@ -27,10 +33,11 @@ export const ExchangeProvider = ({ children }: PropsWithChildren) => {
 };
 
 export function useExchangeContext() {
-  const { celoExchangeRate, stCeloExchangeRate } = useContext(ExchangeContext);
+  const { celoExchangeRate, stCeloExchangeRate, totalCeloBalance } = useContext(ExchangeContext);
 
   return {
     celoExchangeRate,
     stCeloExchangeRate,
+    totalCeloBalance,
   };
 }


### PR DESCRIPTION
- Retrieve from the blockchain the real amount of staked Celo and display it in the footer
- Reload exchange context (exchange rates and total amount of staked Celo) after successful staking/unstaking
- ~⚠️ This is stacked PR! ⚠️~