### PR TITLE
Remove duplicated API requests

### DIFF
--- a/src/hooks/useWithdrawals.ts
+++ b/src/hooks/useWithdrawals.ts
@@ -26,7 +26,6 @@ export const useWithdrawalBot = (address: string | null) => {
   }, [address, managerContract, accountContract]);
 
   useEffect(() => {
-    void finalizeWithdrawal();
     const intervalId = setInterval(finalizeWithdrawal, botActionDelay);
     return () => {
       clearInterval(intervalId);
@@ -56,7 +55,6 @@ export const useClaimingBot = (address: string | null) => {
   }, [address, accountContract, kit.connection]);
 
   useEffect(() => {
-    void claim();
     const intervalId = setInterval(claim, botActionDelay);
     return () => {
       clearInterval(intervalId);


### PR DESCRIPTION
- In order to avoid duplicated API requests during app reload, sent first request after interval