### PR TITLE
Fixed long loading state after tx is submitted

### DIFF
--- a/src/features/swap/hooks/useStaking.ts
+++ b/src/features/swap/hooks/useStaking.ts
@@ -39,7 +39,7 @@ export function useStaking() {
       status: 'signed_transaction',
       value: celoAmount.displayAsBase(),
     });
-    await api.activate();
+    api.activate();
     await loadBalances();
     const postDepositStTokenBalance = new StCelo(
       await stCeloContract.methods.balanceOf(address).call()

--- a/src/features/swap/hooks/useUnstaking.ts
+++ b/src/features/swap/hooks/useUnstaking.ts
@@ -39,7 +39,7 @@ export function useUnstaking() {
       status: 'signed_transaction',
       value: stCeloAmount.displayAsBase(),
     });
-    await api.withdraw(address);
+    api.withdraw(address);
     await Promise.all([loadBalances(), loadPendingWithdrawals()]);
     showUnstakingToast();
     setStCeloAmount(null);


### PR DESCRIPTION
### Description

No longer waiting for backend to complete transactions before updating the app state after a transaction was submitted.

### Related issues

- Fixes #75