### PR TITLE
Refactor onModeChange to be non duplicated

### DIFF
--- a/src/components/switcher/Switcher.tsx
+++ b/src/components/switcher/Switcher.tsx
@@ -1,7 +1,7 @@
-import { useRouter } from 'next/router';
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import scssTransitions from 'src/styles/transitions.module.scss';
 import { Mode } from 'src/types';
+import useModeChange from '../../hooks/useModeChange';
 const { transitionDuration, transitionTimingFunction } = scssTransitions;
 
 interface Link {
@@ -62,17 +62,3 @@ export const Switcher = ({ mode }: SwitcherProps) => {
     </div>
   );
 };
-
-export default function useModeChange() {
-  const router = useRouter();
-  const onModeChange = useCallback(
-    (mode: Mode) => {
-      void router.push({
-        pathname: `/${mode}`,
-      });
-    },
-    [router]
-  );
-
-  return onModeChange;
-}

--- a/src/components/switcher/Switcher.tsx
+++ b/src/components/switcher/Switcher.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { useCallback, useState } from 'react';
 import scssTransitions from 'src/styles/transitions.module.scss';
 import { Mode } from 'src/types';
-
 const { transitionDuration, transitionTimingFunction } = scssTransitions;
 
 interface Link {
@@ -19,13 +19,12 @@ const links: Link[] = [
 
 interface SwitcherProps {
   mode: Mode;
-  onModeChange: (mode: Mode) => void;
 }
 
-export const Switcher = ({ mode, onModeChange }: SwitcherProps) => {
+export const Switcher = ({ mode }: SwitcherProps) => {
   const [activeLink, setActiveLink] = useState<Link | null>(null);
   const [activeLinkNode, setActiveLinkNode] = useState<HTMLElement | null>(null);
-
+  const onModeChange = useModeChange();
   return (
     <div className="flex justify-center mb-[8px] ml-[8px]">
       <nav className="w-full">
@@ -63,3 +62,17 @@ export const Switcher = ({ mode, onModeChange }: SwitcherProps) => {
     </div>
   );
 };
+
+export default function useModeChange() {
+  const router = useRouter();
+  const onModeChange = useCallback(
+    (mode: Mode) => {
+      void router.push({
+        pathname: `/${mode}`,
+      });
+    },
+    [router]
+  );
+
+  return onModeChange;
+}

--- a/src/components/switcher/Switcher.tsx
+++ b/src/components/switcher/Switcher.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import scssTransitions from 'src/styles/transitions.module.scss';
 import { Mode } from 'src/types';
-import useModeChange from '../../hooks/useModeChange';
+import useModeChange from 'src/hooks/useModeChange';
 const { transitionDuration, transitionTimingFunction } = scssTransitions;
 
 interface Link {

--- a/src/features/governance/components/Governance.tsx
+++ b/src/features/governance/components/Governance.tsx
@@ -3,16 +3,12 @@ import { Switcher } from 'src/components/switcher/Switcher';
 import { CenteredLayout } from 'src/layout/CenteredLayout';
 import { Mode } from 'src/types';
 
-interface GovernanceProps {
-  onModeChange: (mode: Mode) => void;
-}
-
-export const Governance = ({ onModeChange }: GovernanceProps) => {
+export const Governance = () => {
   // const _ctx = useAccountContext();
 
   return (
     <CenteredLayout classes="px-[24px]">
-      <Switcher mode={Mode.governance} onModeChange={onModeChange} />
+      <Switcher mode={Mode.governance} />
       <form className="w-full justify-center items-center mt-[24px]">
         <ul className="flex flex-col justify-center w-full bg-secondary p-2 rounded-[16px] gap-2">
           <Row name="Proposal #1" href="/governance/1" />

--- a/src/features/swap/components/Swap.tsx
+++ b/src/features/swap/components/Swap.tsx
@@ -22,7 +22,7 @@ export const Swap = ({ mode, onModeChange }: SwapProps) => {
 
   return (
     <CenteredLayout classes="px-[24px]">
-      <Switcher mode={mode} onModeChange={onModeChange} />
+      <Switcher mode={mode} />
       <SwapForm
         mode={mode}
         amount={amount}

--- a/src/features/swap/components/Swap.tsx
+++ b/src/features/swap/components/Swap.tsx
@@ -9,12 +9,9 @@ import { Details } from './Details';
 import { PendingWithdrawals } from './PendingWithdrawals';
 import { SwapForm } from './SwapForm';
 
-interface SwapProps {
-  mode: Mode;
-  onModeChange: (mode: Mode) => void;
-}
 
-export const Swap = ({ mode, onModeChange }: SwapProps) => {
+
+export const Swap = ({ mode }: SwapProps) => {
   const { pendingWithdrawals } = useAccountContext();
   const { amount, setAmount, swap, balance, receiveAmount, swapRate, gasFee, setMaxAmount } =
     useSwap(mode);
@@ -32,7 +29,6 @@ export const Swap = ({ mode, onModeChange }: SwapProps) => {
         setMaxAmount={setMaxAmount}
         onSubmit={swap}
         onChange={setAmount}
-        onModeChange={onModeChange}
       />
       <OpacityTransition id={mode}>
         <div className="w-full px-[8px]">

--- a/src/features/swap/components/Swap.tsx
+++ b/src/features/swap/components/Swap.tsx
@@ -9,7 +9,9 @@ import { Details } from './Details';
 import { PendingWithdrawals } from './PendingWithdrawals';
 import { SwapForm } from './SwapForm';
 
-
+interface SwapProps {
+  mode: Mode
+}
 
 export const Swap = ({ mode }: SwapProps) => {
   const { pendingWithdrawals } = useAccountContext();

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -5,6 +5,7 @@ import { OpacityTransition } from 'src/components/transitions/OpacityTransition'
 import { DISPLAY_DECIMALS } from 'src/config/consts';
 import { useProtocolContext } from 'src/contexts/protocol/ProtocolContext';
 import { TxCallbacks } from 'src/hooks/useBlockchain';
+import useModeChange from 'src/hooks/useModeChange';
 import { Mode } from 'src/types';
 import { Token, toToken } from 'src/utils/tokens';
 import { BalanceTools } from './BalanceTools';
@@ -22,7 +23,6 @@ interface SwapFormProps {
   setMaxAmount: () => void;
   onSubmit: (callbacks: TxCallbacks) => void;
   onChange: (amount?: Token) => void;
-  onModeChange: (mode: Mode) => void;
 }
 
 export const SwapForm = ({
@@ -34,7 +34,6 @@ export const SwapForm = ({
   setMaxAmount,
   onSubmit,
   onChange,
-  onModeChange,
 }: SwapFormProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const [isCalloutModalOpened, setIsCalloutModalOpened] = useState(false);
@@ -57,6 +56,7 @@ export const SwapForm = ({
     [onSubmit, reloadProtocolContext]
   );
 
+  const onModeChange = useModeChange();
   return (
     <>
       <form className="w-full justify-center items-center mt-[24px]" onSubmit={submit}>

--- a/src/features/validators/components/Validators.tsx
+++ b/src/features/validators/components/Validators.tsx
@@ -4,10 +4,6 @@ import { ValidatorGroupRow } from 'src/features/validators/ValidatorGroupRow';
 import { CenteredLayout } from 'src/layout/CenteredLayout';
 import { Mode } from 'src/types';
 
-interface ValidatorsProps {
-  onModeChange: (mode: Mode) => void;
-}
-
 const groups = [
   {
     name: 'Figment',
@@ -74,12 +70,12 @@ const groups = [
     address: '0x01b2b83fDf26aFC3Ca7062C35Bc68c8DdE56dB04',
   },
 ];
-export const Validators = ({ onModeChange }: ValidatorsProps) => {
+export const Validators = () => {
   const _ctx = useAccountContext();
 
   return (
     <CenteredLayout classes="px-[24px]">
-      <Switcher mode={Mode.validators} onModeChange={onModeChange} />
+      <Switcher mode={Mode.validators} />
       <ul className="flex flex-col justify-center w-full bg-secondary mt-2 p-2 rounded-[16px] gap-2">
         <ValidatorGroupRow
           name="Default Strategy"

--- a/src/hooks/useModeChange.tsx
+++ b/src/hooks/useModeChange.tsx
@@ -1,0 +1,17 @@
+import { useRouter } from 'next/router';
+import { useCallback } from 'react';
+import { Mode } from 'src/types';
+
+export default function useModeChange() {
+  const router = useRouter();
+  const onModeChange = useCallback(
+    (mode: Mode) => {
+      void router.push({
+        pathname: `/${mode}`,
+      });
+    },
+    [router]
+  );
+
+  return onModeChange;
+}

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -8,13 +8,8 @@ const SwapPage: NextPage = () => {
   const { slug } = router.query as { slug?: string[] };
   const mode = slug ? slug[0] : Mode.stake;
 
-  const onModeChange = (mode: Mode) => {
-    void router.push({
-      pathname: `/${mode}`,
-    });
-  };
   if (typeof mode !== 'string' || !Object.values(Mode).includes(mode as Mode)) return null;
-  return <Swap mode={mode as Mode} onModeChange={onModeChange} />;
+  return <Swap mode={mode as Mode} />;
 };
 
 export default SwapPage;

--- a/src/pages/governance.tsx
+++ b/src/pages/governance.tsx
@@ -1,16 +1,9 @@
 import type { NextPage } from 'next';
-import { useRouter } from 'next/router';
 import { Governance } from 'src/features/governance/components/Governance';
-import { Mode } from 'src/types';
 
 const GovernancePage: NextPage = () => {
-  const router = useRouter();
-  const onModeChange = (mode: Mode) => {
-    void router.push({
-      pathname: `/${mode}`,
-    });
-  };
-  return <Governance onModeChange={onModeChange} />;
+
+  return <Governance />;
 };
 
 export default GovernancePage;

--- a/src/pages/validators.tsx
+++ b/src/pages/validators.tsx
@@ -1,16 +1,8 @@
 import type { NextPage } from 'next';
-import { useRouter } from 'next/router';
 import { Validators } from 'src/features/validators/components/Validators';
-import { Mode } from 'src/types';
 
 const ValidatorsPage: NextPage = () => {
-  const router = useRouter();
-  const onModeChange = (mode: Mode) => {
-    void router.push({
-      pathname: `/${mode}`,
-    });
-  };
-  return <Validators onModeChange={onModeChange} />;
+  return <Validators />;
 };
 
 export default ValidatorsPage;


### PR DESCRIPTION
rather then defining an `onModeChange` function in every page and passing it thru to `Switcher` and `SwapForm` use one shared hook between both. 