### PR TITLE
feat: add governance layout and detail page

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "axios": "^0.27.2",
     "bignumber.js": "^9.0.2",
     "compliance-sdk": "^1.0.5",
+    "date-fns": "^2.29.3",
     "dayjs": "^1.11.4",
     "next": "12.2.1",
     "react": "18.2.0",

--- a/src/components/buttons/RadioButton.tsx
+++ b/src/components/buttons/RadioButton.tsx
@@ -2,6 +2,7 @@ import { PropsWithChildren, useId } from 'react';
 
 interface RadioButtonProps {
   checked?: boolean;
+  disabled?: boolean;
   onChange?: () => void;
   classes?: string;
 }
@@ -11,12 +12,13 @@ export const RadioButton = (props: PropsWithChildren<RadioButtonProps>) => {
   const containerClasses = 'flex items-center mb-4';
   const radioClasses =
     'w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600';
-  const textClasses = 'ml-2 text-sm font-medium text-gray-900 dark:text-gray-300';
+  const textClasses = 'ml-2 text-sm font-medium text-color-primary';
 
   return (
     <div className={containerClasses}>
       <input
         checked={!!props.checked}
+        disabled={!!props.disabled}
         id={id}
         type="radio"
         value=""
@@ -24,7 +26,7 @@ export const RadioButton = (props: PropsWithChildren<RadioButtonProps>) => {
         className={radioClasses}
         onChange={props.onChange}
       />
-      <label htmlFor={id} className={textClasses}>
+      <label htmlFor={id} className={`${textClasses} ${props.disabled ? 'opacity-50' : ''}`}>
         {props.children}
       </label>
     </div>

--- a/src/components/buttons/RadioButton.tsx
+++ b/src/components/buttons/RadioButton.tsx
@@ -1,0 +1,32 @@
+import { PropsWithChildren, useId } from 'react';
+
+interface RadioButtonProps {
+  checked?: boolean;
+  onChange?: () => void;
+  classes?: string;
+}
+
+export const RadioButton = (props: PropsWithChildren<RadioButtonProps>) => {
+  const id = useId();
+  const containerClasses = 'flex items-center mb-4';
+  const radioClasses =
+    'w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600';
+  const textClasses = 'ml-2 text-sm font-medium text-gray-900 dark:text-gray-300';
+
+  return (
+    <div className={containerClasses}>
+      <input
+        checked={!!props.checked}
+        id={id}
+        type="radio"
+        value=""
+        name="radio-btn"
+        className={radioClasses}
+        onChange={props.onChange}
+      />
+      <label htmlFor={id} className={textClasses}>
+        {props.children}
+      </label>
+    </div>
+  );
+};

--- a/src/components/list/row.tsx
+++ b/src/components/list/row.tsx
@@ -9,7 +9,8 @@ interface Props {
 }
 
 export const Row = (props: PropsWithChildren<Props>) => {
-  const layoutStyles = 'list-none flex flex-initial flex-row justify-between items-center';
+  const layoutStyles =
+    'list-none flex flex-initial flex-row justify-between items-center max-w-full';
   const spacingStyles = 'gap-5 py-1 px-2';
   const styleStyles = 'bg-primary rounded-lg';
   const highLightedStyles = 'border border-solid border-emerald-200 color-emerald-200';

--- a/src/components/list/row.tsx
+++ b/src/components/list/row.tsx
@@ -29,7 +29,7 @@ export const Row = (props: PropsWithChildren<Props>) => {
           target={props.href?.startsWith('http') ? '_blank' : '_self'}
           rel="noreferrer"
         >
-          <ThemedIcon name="arrow" alt="open" classes="rotate-[270deg]" />
+          <ThemedIcon name="arrow" alt="open" classes="rotate-[270deg] cursor-pointer" />
         </Link>
       </span>
     </li>

--- a/src/components/list/row.tsx
+++ b/src/components/list/row.tsx
@@ -4,6 +4,7 @@ import { ThemedIcon } from 'src/components/icons/ThemedIcon';
 
 interface Props {
   name: string;
+  nameClasses?: string;
   highlighted?: boolean;
   href: string;
 }
@@ -21,7 +22,7 @@ export const Row = (props: PropsWithChildren<Props>) => {
         props.highlighted ? highLightedStyles : ''
       }`}
     >
-      <span className="truncate">{props.name}</span>
+      <span className={`truncate ${props.nameClasses || ''}`}>{props.name}</span>
       <span className={`flex flex-initial flex-shrink-0 flex-row items-center gap-2`}>
         {props.children}
         <Link

--- a/src/components/pills/Pill.tsx
+++ b/src/components/pills/Pill.tsx
@@ -6,9 +6,7 @@ interface LabelProps {
 
 export const Pill = ({ children, classes = '' }: PropsWithChildren<LabelProps>) => {
   return (
-    <span
-      className={`rounded-lg px-2 py-1 bg-action-secondary-regular text-[12px] leading-[14px] font-medium ${classes}`}
-    >
+    <span className={`rounded-lg px-2 py-1 text-[12px] leading-[14px] font-medium ${classes}`}>
       {children}
     </span>
   );

--- a/src/components/switcher/Switcher.tsx
+++ b/src/components/switcher/Switcher.tsx
@@ -26,7 +26,6 @@ export const Switcher = ({ mode }: SwitcherProps) => {
   const [activeLinkNode, setActiveLinkNode] = useState<HTMLElement | null>(null);
   const onModeChange = useModeChange();
 
-  console.log({ left: activeLinkNode?.offsetLeft, width: activeLinkNode?.offsetWidth });
   return (
     <div className="flex justify-center mb-[8px] ml-[8px]">
       <nav className="w-full">

--- a/src/components/switcher/Switcher.tsx
+++ b/src/components/switcher/Switcher.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
+import useModeChange from 'src/hooks/useModeChange';
 import scssTransitions from 'src/styles/transitions.module.scss';
 import { Mode } from 'src/types';
-import useModeChange from 'src/hooks/useModeChange';
 const { transitionDuration, transitionTimingFunction } = scssTransitions;
 
 interface Link {
@@ -13,8 +13,8 @@ interface Link {
 const links: Link[] = [
   { label: 'Stake', mode: Mode.stake, activeBgClass: 'bg-highlight-primary' },
   { label: 'Unstake', mode: Mode.unstake, activeBgClass: 'bg-highlight-secondary' },
-  { label: 'Govern', mode: Mode.governance, activeBgClass: 'color-error' },
-  { label: 'Vote', mode: Mode.validators, activeBgClass: 'color-error' },
+  { label: 'Govern', mode: Mode.governance, activeBgClass: 'bg-action-secondary-callout' },
+  { label: 'Vote', mode: Mode.validators, activeBgClass: 'bg-action-secondary-callout' },
 ];
 
 interface SwitcherProps {
@@ -25,6 +25,8 @@ export const Switcher = ({ mode }: SwitcherProps) => {
   const [activeLink, setActiveLink] = useState<Link | null>(null);
   const [activeLinkNode, setActiveLinkNode] = useState<HTMLElement | null>(null);
   const onModeChange = useModeChange();
+
+  console.log({ left: activeLinkNode?.offsetLeft, width: activeLinkNode?.offsetWidth });
   return (
     <div className="flex justify-center mb-[8px] ml-[8px]">
       <nav className="w-full">

--- a/src/features/governance/components/Choices.tsx
+++ b/src/features/governance/components/Choices.tsx
@@ -12,16 +12,18 @@ export const Choices = ({ voteType, disabled, onChange }: ChoiceProps) => {
     <div className="flex flex-col bg-primary p-[8px] rounded-[16px] gap-4 w-full">
       <span className="font-medium text-[14px] text-color-secondary">vote</span>
       <div className="flex flex-row justify-evenly">
-        {Object.values(VoteType).map((value) => (
-          <RadioButton
-            key={value}
-            disabled={!!disabled}
-            checked={voteType === value}
-            onChange={() => onChange(value as VoteType)}
-          >
-            {<span className="capitalize">{value}</span>}
-          </RadioButton>
-        ))}
+        {Object.values(VoteType)
+          .filter((x) => x !== VoteType.upvote)
+          .map((value) => (
+            <RadioButton
+              key={value}
+              disabled={!!disabled}
+              checked={voteType === value}
+              onChange={() => onChange(value as VoteType)}
+            >
+              {<span className="capitalize">{value}</span>}
+            </RadioButton>
+          ))}
       </div>
     </div>
   );

--- a/src/features/governance/components/Choices.tsx
+++ b/src/features/governance/components/Choices.tsx
@@ -12,18 +12,16 @@ export const Choices = ({ voteType, disabled, onChange }: ChoiceProps) => {
     <div className="flex flex-col bg-primary p-[8px] rounded-[16px] gap-4 w-full">
       <span className="font-medium text-[14px] text-color-secondary">vote</span>
       <div className="flex flex-row justify-evenly">
-        {Object.values(VoteType)
-          .filter((x) => x !== VoteType.upvote)
-          .map((value) => (
-            <RadioButton
-              key={value}
-              disabled={!!disabled}
-              checked={voteType === value}
-              onChange={() => onChange(value as VoteType)}
-            >
-              {<span className="capitalize">{value}</span>}
-            </RadioButton>
-          ))}
+        {Object.values(VoteType).map((value) => (
+          <RadioButton
+            key={value}
+            disabled={!!disabled}
+            checked={voteType === value}
+            onChange={() => onChange(value as VoteType)}
+          >
+            {<span className="capitalize">{value}</span>}
+          </RadioButton>
+        ))}
       </div>
     </div>
   );

--- a/src/features/governance/components/Choices.tsx
+++ b/src/features/governance/components/Choices.tsx
@@ -1,23 +1,21 @@
 import { RadioButton } from 'src/components/buttons/RadioButton';
+import { VoteType } from 'src/types';
 
-export enum VoteType {
-  yes = 'yes',
-  no = 'no',
-  abstain = 'abstain',
-}
-export type VoteProps = {
+export type ChoiceProps = {
   voteType: VoteType | undefined;
+  disabled?: boolean;
   onChange: (voteType: VoteType) => void;
 };
 
-export const Vote = ({ voteType, onChange }: VoteProps) => {
+export const Choices = ({ voteType, disabled, onChange }: ChoiceProps) => {
   return (
     <div className="flex flex-col bg-primary p-[8px] rounded-[16px] gap-4 w-full">
-      <span className="font-medium text-[16px] text-color-secondary">vote</span>
+      <span className="font-medium text-[14px] text-color-secondary">vote</span>
       <div className="flex flex-row justify-evenly">
         {Object.values(VoteType).map((value) => (
           <RadioButton
             key={value}
+            disabled={!!disabled}
             checked={voteType === value}
             onChange={() => onChange(value as VoteType)}
           >

--- a/src/features/governance/components/Details.tsx
+++ b/src/features/governance/components/Details.tsx
@@ -2,11 +2,12 @@ import { ProposalStage } from '@celo/contractkit/lib/wrappers/Governance';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Button } from 'src/components/buttons/Button';
 import { ThemedIcon } from 'src/components/icons/ThemedIcon';
-import { Vote, VoteType } from 'src/features/governance/components/Vote';
+import { Choices } from 'src/features/governance/components/Choices';
+import { VoteButton } from 'src/features/governance/components/VoteButton';
 import { useGovernance } from 'src/hooks/useGovernance';
 import { CenteredLayout } from 'src/layout/CenteredLayout';
+import { VoteType } from 'src/types';
 
 export const Details = () => {
   const router = useRouter();
@@ -40,26 +41,34 @@ export const Details = () => {
     if (!proposal) void loadSpecificProposal(id);
   }, [id, loadSpecificProposal, proposal]);
 
+  const loaded = Boolean(proposal?.parsedYAML);
+
   return (
     <CenteredLayout classes="px-[24px]">
-      <div className="w-full justify-center items-center mt-[24px] ">
-        <div className="flex flex-col w-full bg-secondary p-[8px] rounded-[16px] gap-4">
-          {proposal?.parsedYAML ? (
-            <div className="flex flex-col justify-center bg-primary p-[8px] rounded-[16px] gap-4">
-              <Link href="/governance">
-                <div className="flex flex-row items-center bg-primary rounded-[16px] gap-2">
-                  <ThemedIcon name="arrow" alt="open" classes="rotate-[90deg]" />
-                  <span className="font-medium text-[16px] text-color-secondary">
-                    return to proposals
-                  </span>
-                </div>
-              </Link>
+      <div className="w-full flex flex-col justify-center items-center mt-[24px] bg-secondary p-[8px] rounded-[16px] gap-4">
+        <div className="flex justify-center bg-primary p-[8px] rounded-[16px] w-full">
+          {loaded ? (
+            <div className="flex flex-col justify-center gap-4">
+              <div className="flex flex-row items-center bg-primary rounded-[16px] gap-2">
+                <Link href="/governance">
+                  <ThemedIcon
+                    name="arrow"
+                    alt="open"
+                    classes="rotate-[90deg] cursor-pointer"
+                    height={24}
+                    width={24}
+                  />
+                </Link>
+                <span className="font-medium text-[14px] text-color-secondary">
+                  return to proposals
+                </span>
+              </div>
               <div className="text-[18px] text-color-primary">
-                #{proposal.parsedYAML.cgp} {proposal.parsedYAML.title}
+                #{proposal!.parsedYAML!.cgp} {proposal!.parsedYAML!.title}
               </div>
               <a
                 className="text-[16px] leading-[32px] text-color-callout-modal"
-                href={proposal.metadata.descriptionURL}
+                href={proposal!.metadata.descriptionURL}
                 target="_blank"
                 rel="noreferrer"
               >
@@ -86,25 +95,23 @@ export const Details = () => {
               height={40}
             />
           )}
-          {ProposalStage.Referendum === proposal?.stage && (
-            <>
-              <Vote onChange={onVoteChange} voteType={currentVote} />
-              {currentVote !== undefined && (
-                <span className="text-[18px] text-color-tertiary-callout">
-                  XXX stCELO will vote {currentVote} for Proposal #{proposal.parsedYAML?.cgp}
-                </span>
-              )}
-              <div className="w-full px-4 py-2">
-                <Button
-                  disabled={currentVote === undefined}
-                  classes="bg-action-primary-regular disabled:bg-action-primary-light hover:bg-action-primary-dark active:bg-action-primary-light text-color-contrast w-full"
-                >
-                  Vote
-                </Button>
-              </div>
-            </>
-          )}
         </div>
+        {ProposalStage.Referendum === proposal?.stage && (
+          <>
+            <Choices disabled={!loaded || !!error} onChange={onVoteChange} voteType={currentVote} />
+            {currentVote !== undefined && (
+              <span className="text-[18px] text-color-tertiary-callout">
+                XXX stCELO will vote {currentVote} for Proposal #{proposal.parsedYAML?.cgp}
+              </span>
+            )}
+            <div className="w-full px-4 py-2">
+              <VoteButton
+                disabled={!loaded || !!error || currentVote === undefined}
+                pending={false}
+              />
+            </div>
+          </>
+        )}
       </div>
     </CenteredLayout>
   );

--- a/src/features/governance/components/Details.tsx
+++ b/src/features/governance/components/Details.tsx
@@ -1,4 +1,11 @@
+import { ProposalStage } from '@celo/contractkit/lib/wrappers/Governance';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button } from 'src/components/buttons/Button';
+import { ThemedIcon } from 'src/components/icons/ThemedIcon';
+import { Vote, VoteType } from 'src/features/governance/components/Vote';
+import { useGovernance } from 'src/hooks/useGovernance';
 import { CenteredLayout } from 'src/layout/CenteredLayout';
 
 export const Details = () => {
@@ -7,9 +14,98 @@ export const Details = () => {
     slug: [id],
   } = router.query as { slug: string[] };
 
+  const { loadSpecificProposal, allProposals, error } = useGovernance();
+  const [currentVote, setCurrentVote] = useState<VoteType>();
+
+  // maybe that's less efficient but much easier to understand.
+  // const [proposal, setProposal] = useState<Proposal>();
+  // const [error, setError] = useState<Error>();
+
+  // useEffect(() => {
+  //   void getProposalRecord(id)
+  //     .then((proposal) => setProposal(proposal!))
+  //     .catch(setError);
+  // }, [getProposalRecord, id]);
+
+  const proposal = useMemo(
+    () => allProposals.find((x) => x.proposalID.toString() === id),
+    [id, allProposals]
+  );
+
+  const onVoteChange = useCallback((voteType: VoteType) => {
+    setCurrentVote(voteType);
+  }, []);
+
+  useEffect(() => {
+    if (!proposal) void loadSpecificProposal(id);
+  }, [id, loadSpecificProposal, proposal]);
+
   return (
     <CenteredLayout classes="px-[24px]">
-      <div>Governance details for proposal #{id}</div>
+      <div className="w-full justify-center items-center mt-[24px] ">
+        <div className="flex flex-col w-full bg-secondary p-[8px] rounded-[16px] gap-4">
+          {proposal?.parsedYAML ? (
+            <div className="flex flex-col justify-center bg-primary p-[8px] rounded-[16px] gap-4">
+              <Link href="/governance">
+                <div className="flex flex-row items-center bg-primary rounded-[16px] gap-2">
+                  <ThemedIcon name="arrow" alt="open" classes="rotate-[90deg]" />
+                  <span className="font-medium text-[16px] text-color-secondary">
+                    return to proposals
+                  </span>
+                </div>
+              </Link>
+              <div className="text-[18px] text-color-primary">
+                #{proposal.parsedYAML.cgp} {proposal.parsedYAML.title}
+              </div>
+              <a
+                className="text-[16px] leading-[32px] text-color-callout-modal"
+                href={proposal.metadata.descriptionURL}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <div className="flex flex-row items-center bg-primary rounded-[16px] gap-2">
+                  view info{' '}
+                  <ThemedIcon
+                    name="caret-purple"
+                    alt="open"
+                    classes="rotate-[270deg]"
+                    width={16}
+                    height={16}
+                  />
+                </div>
+              </a>
+            </div>
+          ) : error ? (
+            <div>Couldnt get proposal information from github: {error.message}</div>
+          ) : (
+            <ThemedIcon
+              classes="animate-spin"
+              name="spinner-contrast"
+              alt="Spinner"
+              width={40}
+              height={40}
+            />
+          )}
+          {ProposalStage.Referendum === proposal?.stage && (
+            <>
+              <Vote onChange={onVoteChange} voteType={currentVote} />
+              {currentVote !== undefined && (
+                <span className="text-[18px] text-color-tertiary-callout">
+                  XXX stCELO will vote {currentVote} for Proposal #{proposal.parsedYAML?.cgp}
+                </span>
+              )}
+              <div className="w-full px-4 py-2">
+                <Button
+                  disabled={currentVote === undefined}
+                  classes="bg-action-primary-regular disabled:bg-action-primary-light hover:bg-action-primary-dark active:bg-action-primary-light text-color-contrast w-full"
+                >
+                  Vote
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
     </CenteredLayout>
   );
 };

--- a/src/features/governance/components/Details.tsx
+++ b/src/features/governance/components/Details.tsx
@@ -3,9 +3,11 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ThemedIcon } from 'src/components/icons/ThemedIcon';
+import { useAccountAddress } from 'src/contexts/account/useAddress';
+import { useAccountBalances } from 'src/contexts/account/useBalances';
 import { Choices } from 'src/features/governance/components/Choices';
 import { VoteButton } from 'src/features/governance/components/VoteButton';
-import { useGovernance } from 'src/hooks/useGovernance';
+import { useCeloGovernance } from 'src/hooks/useCeloGovernance';
 import { CenteredLayout } from 'src/layout/CenteredLayout';
 import { VoteType } from 'src/types';
 
@@ -14,8 +16,14 @@ export const Details = () => {
   const {
     slug: [id],
   } = router.query as { slug: string[] };
+  const { address } = useAccountAddress();
+  const { stCeloBalance, loadBalances } = useAccountBalances(address);
 
-  const { loadSpecificProposal, allProposals, error } = useGovernance();
+  useEffect(() => {
+    void loadBalances();
+  }, [loadBalances]);
+
+  const { loadSpecificProposal, allProposals, error } = useCeloGovernance();
   const [currentVote, setCurrentVote] = useState<VoteType>();
 
   // maybe that's less efficient but much easier to understand.
@@ -104,7 +112,8 @@ export const Details = () => {
             <Choices disabled={!loaded || !!error} onChange={onVoteChange} voteType={currentVote} />
             {currentVote !== undefined && (
               <span className="text-[18px] text-color-tertiary-callout">
-                XXX stCELO will vote {currentVote} for Proposal #{proposal.parsedYAML?.cgp}
+                {stCeloBalance.displayAsBase()} stCELO will vote {currentVote} for Proposal #
+                {proposal.parsedYAML?.cgp}
               </span>
             )}
             <div className="w-full px-4 py-2">

--- a/src/features/governance/components/Details.tsx
+++ b/src/features/governance/components/Details.tsx
@@ -41,7 +41,8 @@ export const Details = () => {
     if (!proposal) void loadSpecificProposal(id);
   }, [id, loadSpecificProposal, proposal]);
 
-  const loaded = Boolean(proposal?.parsedYAML);
+  const loaded = Boolean(proposal);
+  const fetchError = Boolean(loaded && !proposal?.parsedYAML);
 
   return (
     <CenteredLayout classes="px-[24px]">
@@ -64,7 +65,9 @@ export const Details = () => {
                 </span>
               </div>
               <div className="text-[18px] text-color-primary">
-                #{proposal!.parsedYAML!.cgp} {proposal!.parsedYAML!.title}
+                {fetchError
+                  ? 'Failed to fetch proposal title'
+                  : `#${proposal!.parsedYAML!.cgp} ${proposal!.parsedYAML!.title}`}
               </div>
               <a
                 className="text-[16px] leading-[32px] text-color-callout-modal"

--- a/src/features/governance/components/Governance.tsx
+++ b/src/features/governance/components/Governance.tsx
@@ -6,11 +6,7 @@ import { useGovernance } from 'src/hooks/useGovernance';
 import { CenteredLayout } from 'src/layout/CenteredLayout';
 import { Mode } from 'src/types';
 
-interface GovernanceProps {
-  onModeChange: (mode: Mode) => void;
-}
-
-export const Governance = ({ onModeChange }: GovernanceProps) => {
+export const Governance = () => {
   const { loadDequeue, approval, referendum, error } = useGovernance();
   useEffect(() => {
     void loadDequeue();

--- a/src/features/governance/components/Governance.tsx
+++ b/src/features/governance/components/Governance.tsx
@@ -1,19 +1,55 @@
+import { useEffect, useMemo } from 'react';
+import { ThemedIcon } from 'src/components/icons/ThemedIcon';
 import { Row } from 'src/components/list/row';
 import { Switcher } from 'src/components/switcher/Switcher';
+import { useGovernance } from 'src/hooks/useGovernance';
 import { CenteredLayout } from 'src/layout/CenteredLayout';
 import { Mode } from 'src/types';
 
-export const Governance = () => {
-  // const _ctx = useAccountContext();
+interface GovernanceProps {
+  onModeChange: (mode: Mode) => void;
+}
+
+export const Governance = ({ onModeChange }: GovernanceProps) => {
+  const { loadDequeue, approval, referendum, error } = useGovernance();
+  useEffect(() => {
+    void loadDequeue();
+  }, [loadDequeue]);
+
+  const proposals = useMemo(
+    () => [...(approval || []), ...(referendum || [])],
+    [approval, referendum]
+  );
 
   return (
     <CenteredLayout classes="px-[24px]">
       <Switcher mode={Mode.governance} />
       <form className="w-full justify-center items-center mt-[24px]">
-        <ul className="flex flex-col justify-center w-full bg-secondary p-2 rounded-[16px] gap-2">
-          <Row name="Proposal #1" href="/governance/1" />
-          <Row name="Proposal #2" href="/governance/2" />
-        </ul>
+        {proposals.length ? (
+          <ul className="flex flex-col justify-center items-stretch w-full bg-secondary p-[8px] rounded-[16px] gap-4">
+            {proposals.map((proposal) => (
+              <Row
+                key={proposal.proposalID.toString()}
+                name={
+                  proposal.parsedYAML
+                    ? proposal.parsedYAML.title
+                    : `Proposal #${proposal.proposalID.toString()}`
+                }
+                href={`/governance/${proposal.proposalID.toString()}`}
+              />
+            ))}
+          </ul>
+        ) : error ? (
+          <div>{error.message}</div>
+        ) : (
+          <ThemedIcon
+            classes="animate-spin"
+            name="spinner-contrast"
+            alt="Spinner"
+            width={40}
+            height={40}
+          />
+        )}
       </form>
     </CenteredLayout>
   );

--- a/src/features/governance/components/Governance.tsx
+++ b/src/features/governance/components/Governance.tsx
@@ -1,52 +1,92 @@
+import { ProposalStage } from '@celo/contractkit/lib/wrappers/Governance';
 import { useEffect, useMemo } from 'react';
 import { ThemedIcon } from 'src/components/icons/ThemedIcon';
 import { Row } from 'src/components/list/row';
-import { Switcher } from 'src/components/switcher/Switcher';
+import { StagePill } from 'src/features/governance/components/StagePill';
 import { useGovernance } from 'src/hooks/useGovernance';
-import { CenteredLayout } from 'src/layout/CenteredLayout';
-import { Mode } from 'src/types';
 
 export const Governance = () => {
-  const { loadDequeue, approval, referendum, error } = useGovernance();
+  const { loadDequeue, allProposals, error } = useGovernance();
   useEffect(() => {
     void loadDequeue();
   }, [loadDequeue]);
 
   const proposals = useMemo(
-    () => [...(approval || []), ...(referendum || [])],
-    [approval, referendum]
+    () =>
+      allProposals.filter((x) =>
+        [ProposalStage.Queued, ProposalStage.Referendum].includes(x.stage)
+      ),
+    [allProposals]
+  );
+  const pastProposals = useMemo(
+    () =>
+      allProposals
+        .filter((x) => [ProposalStage.Expiration, ProposalStage.Execution].includes(x.stage))
+        .slice(0, 5),
+    [allProposals]
   );
 
+  const loaded = proposals.length > 0 || pastProposals.length > 0;
+
   return (
-    <CenteredLayout classes="px-[24px]">
-      <Switcher mode={Mode.governance} />
-      <form className="w-full flex justify-center items-center mt-[24px] bg-secondary p-[8px] rounded-[16px]">
-        {proposals.length ? (
+    <form className="w-full flex flex-col justify-center items-center mt-[24px] bg-secondary p-[8px] pb-4 rounded-[16px] gap-16 min-h-[368px]">
+      {loaded ? (
+        <>
           <ul className="flex flex-col gap-4 w-full">
-            {proposals.map((proposal) => (
-              <Row
-                key={proposal.proposalID.toString()}
-                name={
-                  proposal.parsedYAML
-                    ? proposal.parsedYAML.title
-                    : `Proposal #${proposal.proposalID.toString()}`
-                }
-                href={`/governance/${proposal.proposalID.toString()}`}
-              />
-            ))}
+            {proposals.length > 0 ? (
+              proposals.map((proposal) => (
+                <Row
+                  key={proposal.proposalID.toString()}
+                  name={
+                    proposal.parsedYAML
+                      ? proposal.parsedYAML.title
+                      : `Proposal #${proposal.proposalID.toString()}`
+                  }
+                  href={`/governance/${proposal.proposalID.toString()}`}
+                >
+                  <StagePill stage={proposal.stage} />
+                </Row>
+              ))
+            ) : (
+              <div className="flex flex-col bg-primary p-[8px] rounded-[16px] gap-4 w-full min-h-[70px] justify-center">
+                <span className="text-color-primary pl-4">
+                  Currently no Proposals can be voted on.
+                </span>
+              </div>
+            )}
           </ul>
-        ) : error ? (
-          <div>{error.message}</div>
-        ) : (
-          <ThemedIcon
-            classes="animate-spin"
-            name="spinner-contrast"
-            alt="Spinner"
-            width={40}
-            height={40}
-          />
-        )}
-      </form>
-    </CenteredLayout>
+
+          <div className="flex flex-col gap-4 w-full">
+            <span className="text-color-primary pl-4">Past proposals</span>
+            <ul className="flex flex-col gap-4 w-full">
+              {pastProposals.map((proposal) => (
+                <Row
+                  key={proposal.proposalID.toString()}
+                  name={
+                    proposal.parsedYAML
+                      ? proposal.parsedYAML.title
+                      : `Proposal #${proposal.proposalID.toString()}`
+                  }
+                  nameClasses="text-color-secondary"
+                  href={`/governance/${proposal.proposalID.toString()}`}
+                >
+                  <StagePill stage={proposal.stage} />
+                </Row>
+              ))}
+            </ul>
+          </div>
+        </>
+      ) : error ? (
+        <div>{error.message}</div>
+      ) : (
+        <ThemedIcon
+          classes="animate-spin"
+          name="spinner-contrast"
+          alt="Spinner"
+          width={40}
+          height={40}
+        />
+      )}
+    </form>
   );
 };

--- a/src/features/governance/components/Governance.tsx
+++ b/src/features/governance/components/Governance.tsx
@@ -20,9 +20,9 @@ export const Governance = () => {
   return (
     <CenteredLayout classes="px-[24px]">
       <Switcher mode={Mode.governance} />
-      <form className="w-full justify-center items-center mt-[24px]">
+      <form className="w-full flex justify-center items-center mt-[24px] bg-secondary p-[8px] rounded-[16px]">
         {proposals.length ? (
-          <ul className="flex flex-col justify-center items-stretch w-full bg-secondary p-[8px] rounded-[16px] gap-4">
+          <ul className="flex flex-col gap-4 w-full">
             {proposals.map((proposal) => (
               <Row
                 key={proposal.proposalID.toString()}

--- a/src/features/governance/components/Governance.tsx
+++ b/src/features/governance/components/Governance.tsx
@@ -3,26 +3,22 @@ import { useEffect, useMemo } from 'react';
 import { ThemedIcon } from 'src/components/icons/ThemedIcon';
 import { Row } from 'src/components/list/row';
 import { StagePill } from 'src/features/governance/components/StagePill';
-import { useGovernance } from 'src/hooks/useGovernance';
+import { useCeloGovernance } from 'src/hooks/useCeloGovernance';
 
+const runningProposalStages = new Set([ProposalStage.Queued, ProposalStage.Referendum]);
+const pastProposalStages = new Set([ProposalStage.Expiration, ProposalStage.Execution]);
 export const Governance = () => {
-  const { loadDequeue, allProposals, error } = useGovernance();
+  const { loadDequeue, allProposals, error } = useCeloGovernance();
   useEffect(() => {
     void loadDequeue();
   }, [loadDequeue]);
 
   const proposals = useMemo(
-    () =>
-      allProposals.filter((x) =>
-        [ProposalStage.Queued, ProposalStage.Referendum].includes(x.stage)
-      ),
+    () => allProposals.filter((x) => runningProposalStages.has(x.stage)),
     [allProposals]
   );
   const pastProposals = useMemo(
-    () =>
-      allProposals
-        .filter((x) => [ProposalStage.Expiration, ProposalStage.Execution].includes(x.stage))
-        .slice(0, 5),
+    () => allProposals.filter((x) => pastProposalStages.has(x.stage)).slice(0, 5),
     [allProposals]
   );
 

--- a/src/features/governance/components/StagePill.tsx
+++ b/src/features/governance/components/StagePill.tsx
@@ -1,0 +1,41 @@
+import { ProposalStage } from '@celo/contractkit/lib/wrappers/Governance';
+import { Pill } from 'src/components/pills/Pill';
+
+type StagePillProps = {
+  stage: ProposalStage;
+};
+export const StagePill = ({ stage }: StagePillProps) => {
+  return <Pill classes={stageToBgClass(stage)}>{stageToText(stage)}</Pill>;
+};
+
+function stageToText(stage: ProposalStage) {
+  switch (stage) {
+    case ProposalStage.Approval:
+      return 'approving';
+    case ProposalStage.Execution:
+      return 'passed';
+    case ProposalStage.Expiration:
+      return 'rejected';
+    case ProposalStage.Queued:
+      return 'queued';
+    case ProposalStage.Referendum:
+      return 'voting';
+    case ProposalStage.None:
+      return '';
+  }
+}
+
+function stageToBgClass(stage: ProposalStage) {
+  switch (stage) {
+    case ProposalStage.Queued:
+    case ProposalStage.Approval:
+      return 'bg-secondary';
+    case ProposalStage.Execution:
+    case ProposalStage.Expiration:
+      return 'bg-secondary-oposite text-color-contrast';
+    case ProposalStage.Referendum:
+      return 'bg-action-secondary-callout text-color-contrast';
+    case ProposalStage.None:
+      return 'bg-secondary';
+  }
+}

--- a/src/features/governance/components/Vote.tsx
+++ b/src/features/governance/components/Vote.tsx
@@ -1,0 +1,30 @@
+import { RadioButton } from 'src/components/buttons/RadioButton';
+
+export enum VoteType {
+  yes = 'yes',
+  no = 'no',
+  abstain = 'abstain',
+}
+export type VoteProps = {
+  voteType: VoteType | undefined;
+  onChange: (voteType: VoteType) => void;
+};
+
+export const Vote = ({ voteType, onChange }: VoteProps) => {
+  return (
+    <div className="flex flex-col bg-primary p-[8px] rounded-[16px] gap-4 w-full">
+      <span className="font-medium text-[16px] text-color-secondary">vote</span>
+      <div className="flex flex-row justify-evenly">
+        {Object.values(VoteType).map((value) => (
+          <RadioButton
+            key={value}
+            checked={voteType === value}
+            onChange={() => onChange(value as VoteType)}
+          >
+            {<span className="capitalize">{value}</span>}
+          </RadioButton>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/features/governance/components/VoteButton.tsx
+++ b/src/features/governance/components/VoteButton.tsx
@@ -1,0 +1,30 @@
+import { useId } from 'react';
+import { Button } from 'src/components/buttons/Button';
+import { ThemedIcon } from 'src/components/icons/ThemedIcon';
+import { OpacityTransition } from 'src/components/transitions/OpacityTransition';
+
+interface VoteButtonProps {
+  pending: boolean;
+  disabled?: boolean;
+}
+
+export const VoteButton = ({ pending, disabled }: VoteButtonProps) => {
+  const id = useId();
+  const classes =
+    'bg-action-primary-regular disabled:bg-action-primary-light hover:bg-action-primary-dark active:bg-action-primary-light';
+  return (
+    <Button
+      type="submit"
+      classes={`${classes} text-color-contrast w-full`}
+      disabled={disabled || pending}
+    >
+      {pending ? (
+        <ThemedIcon classes="animate-spin" name="spinner" alt="Spinner" width={40} height={40} />
+      ) : (
+        <OpacityTransition id={id}>
+          <div className="w-full inline-flex justify-center">Vote</div>
+        </OpacityTransition>
+      )}
+    </Button>
+  );
+};

--- a/src/features/swap/components/Swap.tsx
+++ b/src/features/swap/components/Swap.tsx
@@ -1,7 +1,5 @@
-import { Switcher } from 'src/components/switcher/Switcher';
 import { OpacityTransition } from 'src/components/transitions/OpacityTransition';
 import { useAccountContext } from 'src/contexts/account/AccountContext';
-import { CenteredLayout } from 'src/layout/CenteredLayout';
 import { Mode } from 'src/types';
 import { useSwap } from '../hooks/useSwap';
 import { validateAmount } from '../utils/validation';
@@ -10,7 +8,7 @@ import { PendingWithdrawals } from './PendingWithdrawals';
 import { SwapForm } from './SwapForm';
 
 interface SwapProps {
-  mode: Mode
+  mode: Mode;
 }
 
 export const Swap = ({ mode }: SwapProps) => {
@@ -20,8 +18,7 @@ export const Swap = ({ mode }: SwapProps) => {
   const error = validateAmount(amount, balance, mode);
 
   return (
-    <CenteredLayout classes="px-[24px]">
-      <Switcher mode={mode} />
+    <>
       <SwapForm
         mode={mode}
         amount={amount}
@@ -40,6 +37,6 @@ export const Swap = ({ mode }: SwapProps) => {
           ) : null}
         </div>
       </OpacityTransition>
-    </CenteredLayout>
+    </>
   );
 };

--- a/src/features/validators/components/Validators.tsx
+++ b/src/features/validators/components/Validators.tsx
@@ -1,8 +1,4 @@
-import { Switcher } from 'src/components/switcher/Switcher';
-import { useAccountContext } from 'src/contexts/account/AccountContext';
 import { ValidatorGroupRow } from 'src/features/validators/ValidatorGroupRow';
-import { CenteredLayout } from 'src/layout/CenteredLayout';
-import { Mode } from 'src/types';
 
 const groups = [
   {
@@ -71,21 +67,16 @@ const groups = [
   },
 ];
 export const Validators = () => {
-  const _ctx = useAccountContext();
-
   return (
-    <CenteredLayout classes="px-[24px]">
-      <Switcher mode={Mode.validators} />
-      <ul className="flex flex-col justify-center w-full bg-secondary mt-2 p-2 rounded-[16px] gap-2">
-        <ValidatorGroupRow
-          name="Default Strategy"
-          groupAddress="0x0000000000000000000000000000000000000000"
-          isCurrentStrategy={true}
-        />
-        {groups.map((vg) => (
-          <ValidatorGroupRow key={vg.address} name={vg.name} groupAddress={vg.address} />
-        ))}
-      </ul>
-    </CenteredLayout>
+    <ul className="flex flex-col justify-center w-full bg-secondary mt-2 p-2 rounded-[16px] gap-2">
+      <ValidatorGroupRow
+        name="Default Strategy"
+        groupAddress="0x0000000000000000000000000000000000000000"
+        isCurrentStrategy={true}
+      />
+      {groups.map((vg) => (
+        <ValidatorGroupRow key={vg.address} name={vg.name} groupAddress={vg.address} />
+      ))}
+    </ul>
   );
 };

--- a/src/hooks/useCeloGovernance.ts
+++ b/src/hooks/useCeloGovernance.ts
@@ -14,7 +14,7 @@ export type Proposal = ProposalRecord & {
   parsedYAML: ParsedYAML | null;
 };
 
-export function useGovernance() {
+export function useCeloGovernance() {
   const { network } = useCelo();
   const contractKit = useMemo(() => newKit(network.rpcUrl), [network]);
   const [governance, setGovernance] = useState<GovernanceWrapper>();

--- a/src/hooks/useGovernance.ts
+++ b/src/hooks/useGovernance.ts
@@ -25,7 +25,10 @@ export function useGovernance() {
   const [execution, setExecution] = useState<null | Proposal[]>(null);
   const [expiration, setExpiration] = useState<null | Proposal[]>(null);
   const allProposals = useMemo(
-    () => [queue, execution, expiration, approval, referendum].flat().filter(Boolean) as Proposal[],
+    () =>
+      (
+        [queue, execution, expiration, approval, referendum].flat().filter(Boolean) as Proposal[]
+      ).sort((a, b) => b.metadata.timestamp.minus(a.metadata.timestamp).toNumber()),
     [queue, execution, expiration, approval, referendum]
   );
   const [error, setError] = useState<null | Error>(null);
@@ -37,7 +40,9 @@ export function useGovernance() {
       if (!governance) return null;
 
       const proposal = await governance.getProposalRecord(proposalID);
-      const md = await fetch(getRawGithubUrl(proposal)).then((x) => x.text());
+      const md = await fetch(getRawGithubUrl(proposal))
+        .then((x) => x.text())
+        .catch(() => "Failed to fetch proposals' markdown");
 
       return {
         proposalID,

--- a/src/hooks/useGovernance.ts
+++ b/src/hooks/useGovernance.ts
@@ -1,0 +1,162 @@
+import { newKit } from '@celo/contractkit';
+import {
+  GovernanceWrapper,
+  ProposalRecord,
+  ProposalStage,
+} from '@celo/contractkit/lib/wrappers/Governance';
+import { useCelo } from '@celo/react-celo';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getRawGithubUrl, ParsedYAML, parsedYAMLFromMarkdown } from 'src/utils/proposals';
+
+export type Proposal = ProposalRecord & {
+  proposalID: string;
+  markdown: string;
+  parsedYAML: ParsedYAML | null;
+};
+
+export function useGovernance() {
+  const { network } = useCelo();
+  const contractKit = useMemo(() => newKit(network.rpcUrl), [network]);
+  const [governance, setGovernance] = useState<GovernanceWrapper>();
+
+  const [queue, setQueue] = useState<null | Proposal[]>(null);
+  const [approval, setApproval] = useState<null | Proposal[]>(null);
+  const [referendum, setReferendum] = useState<null | Proposal[]>(null);
+  const [execution, setExecution] = useState<null | Proposal[]>(null);
+  const [expiration, setExpiration] = useState<null | Proposal[]>(null);
+  const allProposals = useMemo(
+    () => [queue, execution, expiration, approval, referendum].flat().filter(Boolean) as Proposal[],
+    [queue, execution, expiration, approval, referendum]
+  );
+  const [error, setError] = useState<null | Error>(null);
+
+  useEffect(() => void contractKit.contracts.getGovernance().then(setGovernance), [contractKit]);
+
+  const getProposalRecord = useCallback(
+    async (proposalID: string): Promise<Proposal | null> => {
+      if (!governance) return null;
+
+      const proposal = await governance.getProposalRecord(proposalID);
+      const md = await fetch(getRawGithubUrl(proposal)).then((x) => x.text());
+
+      return {
+        proposalID,
+        markdown: md,
+        parsedYAML: parsedYAMLFromMarkdown(md),
+        ...proposal,
+      };
+    },
+    [governance]
+  );
+
+  const loadQueue = useCallback(async () => {
+    if (!governance) return;
+    try {
+      const _queue = await governance.getQueue();
+      setQueue(
+        await Promise.all(
+          _queue.map(async ({ proposalID }): Promise<Proposal> => {
+            return getProposalRecord(proposalID.toString()) as Promise<Proposal>;
+          })
+        )
+      );
+    } catch (e) {
+      if (e instanceof Error) {
+        setError(e);
+      } else {
+        console.error(e);
+        setError(new Error('Error getting queue proposals'));
+      }
+    }
+  }, [getProposalRecord, governance]);
+
+  const loadDequeue = useCallback(async () => {
+    if (!governance) return;
+    try {
+      const _dequeue = await governance.getDequeue();
+      const proposalsByStage: Record<ProposalStage, Proposal[]> = {
+        [ProposalStage.None]: [],
+        [ProposalStage.Queued]: [],
+        [ProposalStage.Approval]: [],
+        [ProposalStage.Referendum]: [],
+        [ProposalStage.Execution]: [],
+        [ProposalStage.Expiration]: [],
+      };
+      const proposals = await Promise.all(
+        _dequeue.map(async (bn) => {
+          const proposalID = bn.toString();
+          if (proposalID === '0') return null;
+          return getProposalRecord(proposalID);
+        })
+      );
+
+      proposals.filter(Boolean).forEach((proposal) => {
+        proposalsByStage[proposal!.stage].push(proposal!);
+      });
+
+      setApproval(proposalsByStage[ProposalStage.Approval]);
+      setReferendum(proposalsByStage[ProposalStage.Referendum]);
+      setExecution(proposalsByStage[ProposalStage.Execution]);
+      setExpiration(proposalsByStage[ProposalStage.Expiration]);
+    } catch (e) {
+      if (e instanceof Error) {
+        setError(e);
+      } else {
+        console.error(e);
+        setError(new Error('Error getting dequeue proposals'));
+      }
+    }
+  }, [getProposalRecord, governance]);
+
+  const loadSpecificProposal = useCallback(
+    async (id: string) => {
+      if (allProposals.find((x) => x.proposalID.toString() === id)) return;
+      try {
+        const proposal = await getProposalRecord(id);
+        switch (proposal?.stage) {
+          case ProposalStage.Queued:
+            setQueue((x) => (x || []).concat(proposal));
+            break;
+          case ProposalStage.Approval:
+            setApproval((x) => (x || []).concat(proposal));
+            break;
+          case ProposalStage.Referendum:
+            setReferendum((x) => (x || []).concat(proposal));
+            break;
+          case ProposalStage.Execution:
+            setExecution((x) => (x || []).concat(proposal));
+            break;
+          case ProposalStage.Expiration:
+            setExpiration((x) => (x || []).concat(proposal));
+            break;
+          case ProposalStage.None:
+          default:
+            break;
+        }
+      } catch (e) {
+        if (e instanceof Error) {
+          setError(e);
+        } else {
+          console.error(e);
+          setError(new Error('Error getting proposal with id ' + id));
+        }
+      }
+    },
+    [allProposals, getProposalRecord]
+  );
+
+  return {
+    governance,
+    getProposalRecord,
+    loadSpecificProposal,
+    loadDequeue,
+    loadQueue,
+    allProposals,
+    queue,
+    approval,
+    referendum,
+    execution,
+    expiration,
+    error,
+  };
+}

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -8,7 +8,7 @@ import { Validators } from 'src/features/validators/components/Validators';
 import { CenteredLayout } from 'src/layout/CenteredLayout';
 import { Mode } from 'src/types';
 
-const SwapPage: NextPage = () => {
+const CatchAllPage: NextPage = () => {
   const router = useRouter();
   const { slug } = router.query as { slug?: string[] };
   const mode = slug ? slug[0] : Mode.stake;
@@ -37,4 +37,4 @@ const SwapPage: NextPage = () => {
   );
 };
 
-export default SwapPage;
+export default CatchAllPage;

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -1,6 +1,11 @@
 import type { NextPage } from 'next';
 import { useRouter } from 'next/router';
+import { useMemo } from 'react';
+import { Switcher } from 'src/components/switcher/Switcher';
+import { Governance } from 'src/features/governance/components/Governance';
 import { Swap } from 'src/features/swap/components/Swap';
+import { Validators } from 'src/features/validators/components/Validators';
+import { CenteredLayout } from 'src/layout/CenteredLayout';
 import { Mode } from 'src/types';
 
 const SwapPage: NextPage = () => {
@@ -8,8 +13,28 @@ const SwapPage: NextPage = () => {
   const { slug } = router.query as { slug?: string[] };
   const mode = slug ? slug[0] : Mode.stake;
 
-  if (typeof mode !== 'string' || !Object.values(Mode).includes(mode as Mode)) return null;
-  return <Swap mode={mode as Mode} />;
+  const page = useMemo(() => {
+    switch (mode) {
+      case Mode.stake:
+      case Mode.unstake:
+        return <Swap mode={mode as Mode} />;
+      case Mode.governance:
+        return <Governance />;
+      case Mode.validators:
+        return <Validators />;
+      default:
+        return null;
+    }
+  }, [mode]);
+
+  if (!page) return page;
+
+  return (
+    <CenteredLayout classes="px-[24px]">
+      <Switcher mode={mode as Mode} />
+      {page}
+    </CenteredLayout>
+  );
 };
 
 export default SwapPage;

--- a/src/pages/governance.tsx
+++ b/src/pages/governance.tsx
@@ -2,7 +2,6 @@ import type { NextPage } from 'next';
 import { Governance } from 'src/features/governance/components/Governance';
 
 const GovernancePage: NextPage = () => {
-
   return <Governance />;
 };
 

--- a/src/pages/governance.tsx
+++ b/src/pages/governance.tsx
@@ -1,8 +1,0 @@
-import type { NextPage } from 'next';
-import { Governance } from 'src/features/governance/components/Governance';
-
-const GovernancePage: NextPage = () => {
-  return <Governance />;
-};
-
-export default GovernancePage;

--- a/src/pages/validators.tsx
+++ b/src/pages/validators.tsx
@@ -1,8 +1,0 @@
-import type { NextPage } from 'next';
-import { Validators } from 'src/features/validators/components/Validators';
-
-const ValidatorsPage: NextPage = () => {
-  return <Validators />;
-};
-
-export default ValidatorsPage;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,4 +9,5 @@ export enum VoteType {
   yes = 'yes',
   no = 'no',
   abstain = 'abstain',
+  upvote = 'upvote',
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,9 @@ export enum Mode {
   governance = 'governance',
   validators = 'validators',
 }
+
+export enum VoteType {
+  yes = 'yes',
+  no = 'no',
+  abstain = 'abstain',
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,5 +9,4 @@ export enum VoteType {
   yes = 'yes',
   no = 'no',
   abstain = 'abstain',
-  upvote = 'upvote',
 }

--- a/src/utils/proposals.ts
+++ b/src/utils/proposals.ts
@@ -1,0 +1,48 @@
+import { ProposalRecord } from '@celo/contractkit/lib/wrappers/Governance';
+
+export function camelCasesify(str: string): string {
+  const words = str.split(/\W/g);
+
+  return words.map((x, i) => (i === 0 ? x : x.charAt(0).toUpperCase().concat(x.slice(1)))).join('');
+}
+
+export type ParsedYAML = {
+  cgp: string;
+  title: string;
+  dateCreated: string;
+  author: string;
+  status: string;
+  discussionsTo: string;
+  governanceProposalId: string;
+  dateExecuted: string;
+};
+
+export function parsedYAMLFromMarkdown(markdown: string): ParsedYAML | null {
+  const parsed = markdown.match(/---(.*?)---/s);
+  if (!parsed) {
+    return null;
+  }
+  const rows = parsed[1].split('\n');
+  const keyValues = rows
+    .map((x) =>
+      x
+        .split(/(.*?):(.*)/)
+        .map((x) => x.trim())
+        .filter(Boolean)
+    )
+    .filter((x) => x.length);
+
+  return keyValues.reduce(
+    (acc, [key, value]) => ({
+      ...acc,
+      [camelCasesify(key)]: value,
+    }),
+    {} as ParsedYAML
+  );
+}
+
+export function getRawGithubUrl(proposal: ProposalRecord) {
+  return proposal.metadata.descriptionURL
+    .replace('github.com', 'raw.githubusercontent.com')
+    .replace('blob/', '');
+}

--- a/src/utils/proposals.ts
+++ b/src/utils/proposals.ts
@@ -44,5 +44,5 @@ export function parsedYAMLFromMarkdown(markdown: string): ParsedYAML | null {
 export function getRawGithubUrl(proposal: ProposalRecord) {
   return proposal.metadata.descriptionURL
     .replace('github.com', 'raw.githubusercontent.com')
-    .replace('blob/', '');
+    .replace('/blob/', '/');
 }

--- a/src/utils/sanctioned.ts
+++ b/src/utils/sanctioned.ts
@@ -15,7 +15,7 @@ const DAY = 24 * 60 * 60 * 1000;
 
 export async function isSanctionedAddress(address: string): Promise<boolean> {
   const cache = readFromCache(OFAC_SANCTIONS_LIST_URL);
-  if (cache && cache.ts + DAY < Date.now()) {
+  if (cache && cache.ts + DAY > Date.now()) {
     return cache.data.includes(address.toLowerCase());
   }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -38,6 +38,7 @@ module.exports = {
         'action-secondary-light': 'var(--c-bg-action-secondary-light-color)',
         'action-secondary-regular': 'var(--c-bg-action-secondary-regular-color)',
         'action-secondary-dark': 'var(--c-bg-action-secondary-dark-color)',
+        'action-secondary-callout': 'var(--c-text-secondary-callout-color)',
         'highlight-primary': 'var(--c-bg-highlight-primary-color)',
         'highlight-secondary': 'var(--c-bg-highlight-secondary-color)',
         'callout-modal': 'var(--c-bg-callout-modal-color)',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2785,6 +2785,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-fns@^2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
+
 dayjs@^1.11.4:
   version "1.11.4"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.4.tgz#3b3c10ca378140d8917e06ebc13a4922af4f433e"


### PR DESCRIPTION
Add:
- governance list
- governance details
- various governance specific components
- voting layout and logic (not the voting itself tho)
- RadioButton component

Refactor: 
- pages to share the same switcher for css transitions