### PR TITLE
enables withdrawals to work regardless of which contract versions are used.

### DIFF
--- a/src/blockchain/ABIs/v2/DefaultStrategy.json
+++ b/src/blockchain/ABIs/v2/DefaultStrategy.json
@@ -1,0 +1,880 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "previousAdmin",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "AdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "beacon",
+        "type": "address"
+      }
+    ],
+    "name": "BeaconUpgraded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "Upgraded",
+    "type": "event"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "fallback"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  },
+  {
+    "inputs": [],
+    "name": "AddressZeroNotAllowed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "CallerNotManager",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "CallerNotManagerNorStrategy",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "group",
+        "type": "address"
+      }
+    ],
+    "name": "GroupAlreadyAdded",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "group",
+        "type": "address"
+      }
+    ],
+    "name": "GroupNotActive",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "group",
+        "type": "address"
+      }
+    ],
+    "name": "GroupNotEligible",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "group",
+        "type": "address"
+      }
+    ],
+    "name": "HealthyGroup",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "group",
+        "type": "address"
+      }
+    ],
+    "name": "InvalidFromGroup",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "group",
+        "type": "address"
+      }
+    ],
+    "name": "InvalidToGroup",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NoActiveGroups",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotAbleToDistributeVotes",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotUnsortedGroup",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NullAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "group",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "actualCelo",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expectedCelo",
+        "type": "uint256"
+      }
+    ],
+    "name": "RebalanceEnoughStCelo",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "group",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "actualCelo",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expectedCelo",
+        "type": "uint256"
+      }
+    ],
+    "name": "RebalanceNoExtraStCelo",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "group",
+        "type": "address"
+      }
+    ],
+    "name": "GroupActivated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "group",
+        "type": "address"
+      }
+    ],
+    "name": "GroupRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "manager",
+        "type": "address"
+      }
+    ],
+    "name": "ManagerSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "update",
+        "type": "bool"
+      }
+    ],
+    "name": "SortedFlagUpdated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "account",
+    "outputs": [
+      {
+        "internalType": "contract IAccount",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "group",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "lesser",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "greater",
+        "type": "address"
+      }
+    ],
+    "name": "activateGroup",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "group",
+        "type": "address"
+      }
+    ],
+    "name": "deactivateGroup",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "group",
+        "type": "address"
+      }
+    ],
+    "name": "deactivateUnhealthyGroup",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "celoAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "depositGroupToIgnore",
+        "type": "address"
+      }
+    ],
+    "name": "generateDepositVoteDistribution",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "finalGroups",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "finalVotes",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "celoAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "generateWithdrawalVoteDistribution",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "finalGroups",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "finalVotes",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "group",
+        "type": "address"
+      }
+    ],
+    "name": "getExpectedAndActualStCeloForGroup",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "expectedStCelo",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "actualStCelo",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "group",
+        "type": "address"
+      }
+    ],
+    "name": "getGroupPreviousAndNext",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "previousAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "nextAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getGroupsHead",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "head",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "previousAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getGroupsTail",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "tail",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "nextAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getNumberOfGroups",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getNumberOfUnsortedGroups",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "getUnsortedGroupAt",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getVersionNumber",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "groupHealth",
+    "outputs": [
+      {
+        "internalType": "contract IGroupHealth",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_manager",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "group",
+        "type": "address"
+      }
+    ],
+    "name": "isActive",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "manager",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxGroupsToDistributeTo",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxGroupsToWithdrawFrom",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "fromGroup",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "toGroup",
+        "type": "address"
+      }
+    ],
+    "name": "rebalance",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_groupHealth",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_specificGroupStrategy",
+        "type": "address"
+      }
+    ],
+    "name": "setDependencies",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_manager",
+        "type": "address"
+      }
+    ],
+    "name": "setManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "distributeTo",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "withdrawFrom",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "loopLimit",
+        "type": "uint256"
+      }
+    ],
+    "name": "setSortingParams",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "sorted",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "specificGroupStrategy",
+    "outputs": [
+      {
+        "internalType": "contract ISpecificGroupStrategy",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "stCeloInGroup",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalStCeloInStrategy",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "group",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "lesserKey",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "greaterKey",
+        "type": "address"
+      }
+    ],
+    "name": "updateActiveGroupOrder",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      }
+    ],
+    "name": "upgradeTo",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "upgradeToAndCall",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_logic",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "constructor"
+  }
+]

--- a/src/config/contracts.ts
+++ b/src/config/contracts.ts
@@ -8,18 +8,21 @@ import {
 } from 'src/config/consts';
 
 interface ContractAddresses {
+  defaultStrategy: string;
   manager: string;
   stakedCelo: string;
   account: string;
 }
 
 export const mainnetAddresses: ContractAddresses = {
+  defaultStrategy: 'TODO_GET_ADDRESS',
   manager: NEXT_PUBLIC_MANAGER_MAINNET_ADDRESS as string,
   stakedCelo: NEXT_PUBLIC_STAKED_CELO_MAINNET_ADDRESS as string,
   account: NEXT_PUBLIC_ACCOUNT_MAINNET_ADDRESS as string,
 };
 
 export const testnetAddresses: ContractAddresses = {
+  defaultStrategy: 'TODO_GET_ADDRESS',
   manager: NEXT_PUBLIC_MANAGER_TESTNET_ADDRESS as string,
   stakedCelo: NEXT_PUBLIC_STAKED_CELO_TESTNET_ADDRESS as string,
   account: NEXT_PUBLIC_ACCOUNT_TESTNET_ADDRESS as string,

--- a/src/hooks/useBlockchain.ts
+++ b/src/hooks/useBlockchain.ts
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import AccountABI from 'src/blockchain/ABIs/Account.json';
 import ManagerABI from 'src/blockchain/ABIs/Manager.json';
 import StCeloABI from 'src/blockchain/ABIs/StakedCelo.json';
+import DefaultStrategyABi from 'src/blockchain/ABIs/v2/DefaultStrategy.json';
 import { mainnetAddresses, testnetAddresses } from 'src/config/contracts';
 import { isSanctionedAddress } from 'src/utils/sanctioned';
 import { AbiItem } from 'web3-utils';
@@ -54,6 +55,11 @@ export function useBlockchain() {
     return new eth.Contract(StCeloABI as AbiItem[], addresses.stakedCelo);
   }, [kit.connection, addresses]);
 
+  const defaultStrategyContract = useMemo(() => {
+    const { eth } = kit.connection.web3;
+    return new eth.Contract(DefaultStrategyABi as AbiItem[], addresses.defaultStrategy);
+  }, [kit.connection, addresses]);
+
   const accountContract = useMemo(() => {
     const { eth } = kit.connection.web3;
     return new eth.Contract(AccountABI as AbiItem[], addresses.account);
@@ -98,6 +104,7 @@ export function useBlockchain() {
   );
 
   return {
+    defaultStrategyContract,
     epochRewardsContract,
     sortedOraclesContract,
     stableTokenContract,

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,10 @@
+export const writeToCache = (url: string, data: string[]) =>
+  localStorage.setItem(url, JSON.stringify({ ts: Date.now(), data }));
+
+export const readFromCache = (url: string) => {
+  const cached = localStorage.getItem(url);
+  if (cached) {
+    return JSON.parse(cached) as { ts: number; data: string[] };
+  }
+  return null;
+};

--- a/src/utils/sanctioned.ts
+++ b/src/utils/sanctioned.ts
@@ -1,15 +1,5 @@
 import { OFAC_SANCTIONS_LIST_URL, SANCTIONED_ADDRESSES } from 'compliance-sdk';
-
-const writeToCache = (url: string, data: string[]) =>
-  localStorage.setItem(url, JSON.stringify({ ts: Date.now(), data }));
-
-const readFromCache = (url: string) => {
-  const cached = localStorage.getItem(url);
-  if (cached) {
-    return JSON.parse(cached) as { ts: number; data: string[] };
-  }
-  return null;
-};
+import { readFromCache, writeToCache } from './cache';
 
 const DAY = 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION


Method for getting groups changed location and signature from v1 to v2, in order for there to be a seemless transition this pr  enables v2 version as a fallback. 

also store the groups in localstorage for a bit to reduce number of times they need to be fetched. 

Will need deployed addresses still.  