### PR TITLE
Transitions + Names + tiddy

### DIFF
--- a/src/components/switcher/Switcher.tsx
+++ b/src/components/switcher/Switcher.tsx
@@ -13,8 +13,12 @@ interface Link {
 const links: Link[] = [
   { label: 'Stake', mode: Mode.stake, activeBgClass: 'bg-highlight-primary' },
   { label: 'Unstake', mode: Mode.unstake, activeBgClass: 'bg-highlight-secondary' },
-  { label: 'Govern', mode: Mode.governance, activeBgClass: 'bg-action-secondary-callout' },
-  { label: 'Vote', mode: Mode.validators, activeBgClass: 'bg-action-secondary-callout' },
+  { label: 'Governance', mode: Mode.governance, activeBgClass: 'bg-action-secondary-callout' },
+  {
+    label: 'Election',
+    mode: Mode.validators,
+    activeBgClass: 'bg-action-secondary-callout',
+  },
 ];
 
 interface SwitcherProps {

--- a/src/features/validators/components/Details.tsx
+++ b/src/features/validators/components/Details.tsx
@@ -12,6 +12,7 @@ import { ADDRESS_ZERO, EXPLORER_ALFAJORES_URL, EXPLORER_MAINNET_URL } from 'src/
 import { useAccountAddress } from 'src/contexts/account/useAddress';
 import { useAccountBalances } from 'src/contexts/account/useBalances';
 import { removeAddressMiddle } from 'src/features/validators/removeAddressMiddle';
+import { useIsTransitioning } from 'src/hooks/useIsTransitioning';
 import { CenteredLayout } from 'src/layout/CenteredLayout';
 import logger from 'src/services/logger';
 import { Mode } from 'src/types';
@@ -22,6 +23,7 @@ interface Props {
 }
 
 export const Details = ({ groupAddress, name }: Props) => {
+  const isTransitioning = useIsTransitioning();
   const [isTransactionModalOpen, setTransactionModalOpen] = useState(false);
   const { network } = useCelo();
   const { address: myAddress, isConnected } = useAccountAddress();
@@ -51,7 +53,7 @@ export const Details = ({ groupAddress, name }: Props) => {
 
   return (
     <form id={`group-${groupAddress}`} className="w-full flex" onSubmit={onSubmit}>
-      <CenteredLayout classes="px-[24px]">
+      <CenteredLayout classes={`px-[24px] ${isTransitioning && 'animate-pulse'}`}>
         <ContainerSecondaryBG>
           <div className="flex bg-primary p-[8px] rounded-[16px] w-full">
             <div className="flex flex-col gap-4 w-full">

--- a/src/features/validators/components/List.tsx
+++ b/src/features/validators/components/List.tsx
@@ -10,7 +10,7 @@ export const Validators = ({ list }: ValidatorsProps) => {
   const _ctx = useAccountContext();
 
   return (
-    <ul className="flex flex-col justify-center w-full bg-secondary mt-2 p-2 rounded-[16px] gap-2">
+    <ul className="flex flex-col justify-center w-full bg-secondary mt-[24px] p-2 rounded-[16px] gap-2">
       <ValidatorGroupRow
         name="Default Strategy"
         groupAddress="0x0000000000000000000000000000000000000000"
@@ -20,5 +20,5 @@ export const Validators = ({ list }: ValidatorsProps) => {
         <ValidatorGroupRow key={vg.address} name={vg.name} groupAddress={vg.address} />
       ))}
     </ul>
-  )
+  );
 }

--- a/src/hooks/useIsTransitioning.ts
+++ b/src/hooks/useIsTransitioning.ts
@@ -1,0 +1,26 @@
+// components/PageWithTransition.tsx
+import { useRouter } from 'next/router';
+import { useLayoutEffect, useState } from 'react';
+
+export function useIsTransitioning() {
+  const router = useRouter();
+  const [transitioning, setTransitioning] = useState(false);
+  useLayoutEffect(() => {
+    const begin = () => {
+      setTransitioning(true);
+    };
+    const end = () => {
+      setTransitioning(false);
+    };
+    router.events.on('routeChangeStart', begin);
+    router.events.on('routeChangeError', end);
+    router.events.on('routeChangeComplete', end);
+    return () => {
+      router.events.off('routeChangeStart', begin);
+      router.events.off('routeChangeError', end);
+      router.events.off('routeChangeComplete', end);
+    };
+  }, [router.events, router.asPath]);
+
+  return transitioning;
+}

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -6,6 +6,7 @@ import { Governance } from 'src/features/governance/components/Governance';
 import { Swap } from 'src/features/swap/components/Swap';
 import { Validators } from 'src/features/validators/components/List';
 import fetchValidGroups, { ValidatorGroup } from 'src/features/validators/data/fetchValidGroups';
+import { useIsTransitioning } from 'src/hooks/useIsTransitioning';
 import {
   getChainIdFromQuery,
   useRedirectToConnectedChainIfNeeded,
@@ -24,6 +25,7 @@ const MultiModePage: NextPage<Props> = ({ serverSideChainId, validatorGroups }) 
   const mode = (slug ? slug[0] : Mode.stake) as Mode;
 
   useRedirectToConnectedChainIfNeeded(serverSideChainId, mode);
+  const isTransitioning = useIsTransitioning();
 
   const page = useMemo(() => {
     switch (mode) {
@@ -42,7 +44,7 @@ const MultiModePage: NextPage<Props> = ({ serverSideChainId, validatorGroups }) 
   if (!page) return page;
 
   return (
-    <CenteredLayout classes="px-[24px]">
+    <CenteredLayout classes={`px-[24px] ${isTransitioning && 'animate-pulse'}`}>
       <Switcher mode={mode as Mode} />
       {page}
     </CenteredLayout>


### PR DESCRIPTION


* Update Tab names to Goverance and Election
* Add in isTransitioning for Immediate visual change when switching between pages (rather than nothing until page data loads)
* fix top margin on validators list page