### PR TITLE
fix: reenable minification without swc

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@ const webpack = require('webpack');
 
 const nextConfig = {
   reactStrictMode: false,
-  swcMinify: true,
+  swcMinify: false,
   webpack: (config) => {
     config.resolve.fallback = { fs: false, net: false, tls: false };
     config.plugins.push(
@@ -11,7 +11,7 @@ const nextConfig = {
         banner: 'For third party licenses check /THIRD_PARTY_LICENSES.txt',
       })
     );
-    config.optimization.minimizer = [];
+    // config.optimization.minimizer = [];
     return config;
   },
   async headers() {


### PR DESCRIPTION
This re-enables minification with Babel default minifier. We get runtime performance back and no more WCv2 bug. But the build is a _tad_ slower.