### PR TITLE
Adds clarity in UI to how CGP #s and on-chain proposal IDs are displayed on voting pages and details

### DIFF
--- a/src/features/governance/components/Details.tsx
+++ b/src/features/governance/components/Details.tsx
@@ -97,7 +97,9 @@ export const Details = ({ proposal }: Props) => {
                 <div className="text-[18px] text-color-primary">
                   {fetchError
                     ? 'Failed to fetch proposal title'
-                    : `#${proposal!.parsedYAML!.cgp} ${proposal!.parsedYAML!.title}`}
+                    : `CGP-${proposal!.parsedYAML!.cgp} (#${proposal!.proposalID} on-chain) - ${
+                        proposal!.parsedYAML!.title
+                      }`}
                 </div>
                 <LinkOut classes="m-2" href={proposal!.metadata.descriptionURL}>
                   view info

--- a/src/features/governance/components/Governance.tsx
+++ b/src/features/governance/components/Governance.tsx
@@ -26,7 +26,7 @@ export const Governance = ({ proposals, pastProposals }: Props) => {
                   key={proposal.proposalID.toString()}
                   name={
                     proposal.parsedYAML
-                      ? proposal.parsedYAML.title
+                      ? `CGP-${proposal.parsedYAML.cgp} (#${proposal.proposalID}) ${proposal.parsedYAML.title}`
                       : `Proposal #${proposal.proposalID}`
                   }
                   href={`/governance/${proposal.proposalID}`}
@@ -51,7 +51,7 @@ export const Governance = ({ proposals, pastProposals }: Props) => {
                   key={proposal.proposalID.toString()}
                   name={
                     proposal.parsedYAML
-                      ? proposal.parsedYAML.title
+                      ? `CGP-${proposal.parsedYAML.cgp} (#${proposal.proposalID}) ${proposal.parsedYAML.title}`
                       : `Proposal #${proposal.proposalID.toString()}`
                   }
                   nameClasses="text-color-secondary"


### PR DESCRIPTION
Adds CGP# and on-chain proposal IDs to governance proposals and details page.
<img width="490" alt="Screenshot 2023-09-06 at 11 54 37" src="https://github.com/celo-org/staked-celo-web-app/assets/23874/809ae7c9-e65f-438d-979f-39ba36e8e72e">
<img width="495" alt="Screenshot 2023-09-06 at 11 55 03" src="https://github.com/celo-org/staked-celo-web-app/assets/23874/91a9facf-7c9f-4865-afd6-5b7c6e15561e">
