### PR TITLE
Adds Github Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-FORM.yml
@@ -1,0 +1,45 @@
+name: Bug report
+description: File a bug report
+labels: ["bug report"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Please ensure that the bug has not already been filed in the issue tracker.
+
+              Thanks for taking the time to report this bug!
+    - type: dropdown
+      attributes:
+          label: Package
+          description: What feature is the bug in?
+          multiple: true
+          options:
+              - Stake
+              - Unstake
+              - Govern
+              - Select Validator
+              - Other (please describe)
+      validations:
+          required: true
+    - type: input
+      attributes:
+          label: What wallet app are you using to connect?
+          placeholder: "MetaMask, Safe with WalletConnect, Ledger Nano X, ..."
+    - type: dropdown
+      attributes:
+          label: Browser
+          description: What browser and version are you using?
+          options:
+              - Chrome
+              - Opera
+              - Safari
+              - Firefox
+              - Brave
+              - Arc
+              - Other (please describe)
+    - type: textarea
+      attributes:
+          label: Describe the bug
+          description: Please include relevant code snippets, terminal output, and screenshots if relevant.
+      validations:
+          required: true

--- a/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Suggest a feature
+labels: ["feature request"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Please ensure that the feature has not already been requested in the issue tracker.
+
+              Thanks for helping us improve stCelo!
+    - type: dropdown
+      attributes:
+          label: Component
+          description: What is the feature for?
+          multiple: true
+          options:
+              - Stake
+              - Unstake
+              - Govern
+              - Select Validator
+              - Other (please describe)
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: Describe the feature you would like
+          description: Please also describe what the feature is aiming to solve, if relevant.
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: Additional context
+          description: Add any other context to the feature (like screenshots, code snippets, resources)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Github Discussions
+    url: https://github.com/celo-org/staked-celo-web-app/discussions
+    about: Please ask and answer questions here.
+  - name: Docs
+    url: https://docs.stcelo.xyz/
+    about: Documentation for stCelo.


### PR DESCRIPTION
### Description

Adds Github templates for bug reports and feature requests.
Updates template chooser, encouraging users to open Github Discussions for Q&A instead of Discord.

The Foundry repo ([foundry-rs/foundry](https://github.com/foundry-rs/foundry)) has great drop-down template for bug reports and feature requests.

This makes it a lot easier for them to review, reproduce, and fix bugs.

Similar to this: 
- https://github.com/celo-org/developer-tooling/pull/50