### PR TITLE
Adds PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+### Description
+
+_A few sentences describing the overall effects and goals of the pull request's commits.
+What is the current behavior, and what is the updated/expected behavior with this PR?_
+
+### Other changes
+
+_Describe any minor or "drive-by" changes here._
+
+### Tested
+
+_An explanation of how the changes were tested or an explanation as to why they don't need to be._
+
+### Related issues
+
+- Fixes #[issue number here]
+
+### Backwards compatibility
+
+_Brief explanation of why these changes are/are not backwards compatible._
+
+### Documentation
+
+_The set of community facing docs that have been added/modified because of this change_


### PR DESCRIPTION
Adds PR template like we have in [celo-org/developer-tooling](https://github.com/celo-org/developer-tooling): [`pull_request_template.md`](https://github.com/celo-org/developer-tooling/blob/master/.github/pull_request_template.md)

Github docs I used to double-check the file name is still recommended: [Creating a pull request template for your repository](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)

Currently new PRs start with a blank canvas, with this PR our descriptions will follow a more consistent template.