### PR TITLE
fix bug in Token.toBigInt()

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@rainbow-me/rainbowkit": "^1.0.4",
     "@types/react-modal": "^3.13.1",
     "@types/react-transition-group": "^4.4.5",
-    "bignumber.js": "^9.0.2",
+    "bignumber.js": "^9.1.2",
     "compliance-sdk": "^1.0.5",
     "dayjs": "^1.11.4",
     "graphql": "^16.6.0",

--- a/src/utils/tokens.test.ts
+++ b/src/utils/tokens.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest"
+
+import { Token } from "src/utils/tokens"
+
+
+describe('Token', () => {
+  describe('toBigInt', () => {
+    test('it converts to BigInt', () => {
+      expect(new Token(1).toBigInt()).toEqual(1n);
+    });
+    test('it converts very large number BigInt', () => {
+      expect(new Token('123456789000000000000000000').toBigInt()).toEqual(123456789000000000000000000n);
+    })
+  })
+  describe('convertToBase', () => {
+    test('it converts to base', () => {
+      expect(new Token(1).convertToBase().toString()).toEqual('1e-18');
+    });
+    test('it converts very large number to base', () => {
+      expect(new Token('123456789000000000000000000').convertToBase().toString()).toEqual('123456789');
+    })
+  })
+  describe('displayAsBase', () => {
+    test('displays ver small numbers as we think about them', () => {
+      expect(new Token("100000").displayAsBase()).toEqual('0.0000');
+    });
+    test('displays numbers as we think about them', () => {
+      expect(new Token("1234567890000000000").displayAsBase()).toEqual('1.2345');
+    });
+    test('displays big numbers as we think about them', () => {
+      expect(new Token("123456789101112131400000").displayAsBase()).toEqual('123,456.7891');
+    });
+  })
+})

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -29,7 +29,7 @@ export class Token extends BigNumber {
   }
 
   toBigInt(): bigint {
-    return BigInt(this.toNumber());
+    return BigInt(this.toString(10))
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3051,10 +3051,15 @@ bigint-buffer@^1.1.5:
   dependencies:
     bindings "^1.3.0"
 
-bignumber.js@^9.0.0, bignumber.js@^9.0.2:
+bignumber.js@^9.0.0:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.2.tgz#71c6c6bed38de64e24a65ebe16cfcf23ae693673"
   integrity sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==
+
+bignumber.js@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
+  integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
 
 binary-extensions@^2.0.0:
   version "2.2.0"


### PR DESCRIPTION


### Description

To converted to BigInt Token class was calling BigNumber.toNumber() which loses information. This meant the BigInt was different than the Big Number. 

instead convert to string 

### Other changes

add tests for Token

upgrade BigNumber

### Tested

new tests!

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

100%
### Documentation

n/a