### PR TITLE
set renovate config to extend from base config for developer tooling

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>celo-org/.github:renovate-config"
+    "local>celo-org/.github:renovate-config",
+    "local>celo-org/developer-tooling:dt-renovate-base"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
### Description


we are moving all common renovate configs for our team to a central location. 