### PR TITLE
Chores: Twitter/Discord URL, robots.txt file, Bug and feature request URL

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:

--- a/src/config/consts.ts
+++ b/src/config/consts.ts
@@ -34,7 +34,7 @@ export const EXPLORER_MAINNET_URL = 'https://explorer.celo.org/mainnet';
 export const EXPLORER_ALFAJORES_URL = 'https://explorer.celo.org/alfajores';
 
 export const TWITTER_URL = 'https://twitter.com/Celo';
-export const DISCORD_URL = 'https://discord.com/invite/E9AqUQnWQE';
+export const DISCORD_URL = 'https://discord.com/invite/celo';
 export const GITHUB_URL = 'https://github.com/celo-org/staked-celo-web-app';
 export const DOCS_URL = 'https://docs.stcelo.xyz/';
 export const PRIVACY_URL = 'https://clabs.co/privacy';

--- a/src/config/consts.ts
+++ b/src/config/consts.ts
@@ -33,7 +33,7 @@ export const EXPLORER_GRAPH_ALFAJORES_URL = 'https://explorer.celo.org/alfajores
 export const EXPLORER_MAINNET_URL = 'https://explorer.celo.org/mainnet';
 export const EXPLORER_ALFAJORES_URL = 'https://explorer.celo.org/alfajores';
 
-export const TWITTER_URL = 'https://twitter.com/CeloOrg';
+export const TWITTER_URL = 'https://twitter.com/Celo';
 export const DISCORD_URL = 'https://discord.com/invite/E9AqUQnWQE';
 export const GITHUB_URL = 'https://github.com/celo-org/staked-celo-web-app';
 export const DOCS_URL = 'https://docs.stcelo.xyz/';

--- a/src/config/consts.ts
+++ b/src/config/consts.ts
@@ -38,6 +38,8 @@ export const DISCORD_URL = 'https://discord.com/invite/celo';
 export const GITHUB_URL = 'https://github.com/celo-org/staked-celo-web-app';
 export const DOCS_URL = 'https://docs.stcelo.xyz/';
 export const PRIVACY_URL = 'https://clabs.co/privacy';
+export const GITHUB_ISSUES_URL =
+  'https://github.com/celo-org/staked-celo-web-app/issues/new/choose';
 
 export const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000';
 

--- a/src/config/externalUrls.ts
+++ b/src/config/externalUrls.ts
@@ -1,13 +1,15 @@
 import {
   DISCORD_URL,
   DOCS_URL,
+  GITHUB_ISSUES_URL,
   GITHUB_URL,
   PRIVACY_URL,
   TWITTER_URL,
 } from 'src/config/consts';
 
-export const twitterUrl: string = TWITTER_URL
-export const discordUrl: string = DISCORD_URL
-export const githubUrl: string = GITHUB_URL
-export const docsUrl: string = DOCS_URL
-export const privacyUrl: string = PRIVACY_URL
+export const twitterUrl: string = TWITTER_URL;
+export const discordUrl: string = DISCORD_URL;
+export const githubIssuesUrl: string = GITHUB_ISSUES_URL;
+export const githubUrl: string = GITHUB_URL;
+export const docsUrl: string = DOCS_URL;
+export const privacyUrl: string = PRIVACY_URL;

--- a/src/layout/AppLayout/Footer.tsx
+++ b/src/layout/AppLayout/Footer.tsx
@@ -1,7 +1,14 @@
 import Link from 'next/link';
 import { ThemedIcon } from 'src/components/icons/ThemedIcon';
 import { Label } from 'src/components/text/Label';
-import { discordUrl, docsUrl, githubUrl, privacyUrl, twitterUrl } from 'src/config/externalUrls';
+import {
+  discordUrl,
+  docsUrl,
+  githubIssuesUrl,
+  githubUrl,
+  privacyUrl,
+  twitterUrl,
+} from 'src/config/externalUrls';
 import { useProtocolContext } from 'src/contexts/protocol/ProtocolContext';
 
 export const Footer = () => {
@@ -38,6 +45,11 @@ const FAQLinks = ({ classes }: FAQLinksProps) => {
   const linkPositionClasses = 'sm:mb-0 mb-[16px] sm:mr-[24px]';
   return (
     <div className={`text-[18px] leading-[32px] font-medium underline ${classes}`}>
+      <div className={linkPositionClasses}>
+        <a href={githubIssuesUrl} target="_blank" rel="noreferrer">
+          Bugs and feature requests
+        </a>
+      </div>
       <div className={linkPositionClasses}>
         <Link href="/faq">FAQ</Link>
       </div>


### PR DESCRIPTION
### Description

- Updates Discord invite link to `https://discord.com/invite/celo`
- Updates Twitter link to `https://twitter.com/Celo`
- Adds a `robots.txt` file in `/public` folder
- Adds link for "[Bugs and feature requests](https://github.com/celo-org/staked-celo-web-app/issues/new/choose)" to Github Issues
  <img width="350" alt="image" src="https://github.com/celo-org/staked-celo-web-app/assets/46296830/3fef3e69-60b1-47bf-9aa0-c379cc8a7a57">


### References

What are `robots.txt` files good for? https://developers.google.com/search/docs/crawling-indexing/robots/intro

Where should `robots.txt` files live in Next.js projects? https://nextjs.org/learn-pages-router/seo/crawling-and-indexing/robots-txt

### Tested

Using the [Vercel preview](https://staked-celo-web-app-git-arthurgousset-chores-c-labs.vercel.app/connect):
- manually clicked the Twitter and Discord icons
  <img width="150" alt="image" src="https://github.com/celo-org/staked-celo-web-app/assets/46296830/a78b90ee-008a-4100-ba4f-0c04c75421fe">
- manually checked `https://staked-celo-web-app-git-arthurgousset-chores-c-labs.vercel.app/robots.txt`
  <img width="500" alt="image" src="https://github.com/celo-org/staked-celo-web-app/assets/46296830/439c97d1-4b9f-4056-9744-7ef5fe955a9c">
- manually clicked on "[Bugs and feature requests](https://github.com/celo-org/staked-celo-web-app/issues/new/choose)"
  <img width="350" alt="image" src="https://github.com/celo-org/staked-celo-web-app/assets/46296830/9682c06f-b73c-4016-a647-65a42610e0e6">


### Related issues

- Fixes #219 

### Backwards compatibility

Yes, no change to feature set.

### Documentation

N/A