### PR TITLE
Tighten the screws

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,13 @@ const nextConfig = {
   async headers() {
     return [
       {
+        source: '*',
+        headers: {
+          key: 'X-Frame-Options',
+          value: 'DENY',
+        },
+      },
+      {
         source: '/manifest.json',
         headers: [
           {

--- a/next.config.js
+++ b/next.config.js
@@ -17,11 +17,13 @@ const nextConfig = {
   async headers() {
     return [
       {
-        source: '*',
-        headers: {
-          key: 'X-Frame-Options',
-          value: 'DENY',
-        },
+        source: '/:path*',
+        headers: [
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+        ],
       },
       {
         source: '/manifest.json',

--- a/src/features/governance/components/Details.tsx
+++ b/src/features/governance/components/Details.tsx
@@ -14,6 +14,7 @@ import { SerializedProposal } from 'src/features/governance/data/getProposals';
 import { useVote } from 'src/features/governance/hooks/useVote';
 import { CenteredLayout } from 'src/layout/CenteredLayout';
 import { Mode, VoteType } from 'src/types';
+import { restrictToCeloGovernanceLink } from 'src/utils/proposals';
 import { StCelo } from 'src/utils/tokens';
 import { BackToListButton } from '../../../components/buttons/BackToListButton';
 
@@ -82,7 +83,7 @@ export const Details = ({ proposal }: Props) => {
 
   const loaded = Boolean(proposal);
   const fetchError = Boolean(loaded && !proposal?.parsedYAML);
-
+  const saferDescriptionUrl = restrictToCeloGovernanceLink(proposal?.metadata.descriptionURL);
   return (
     <CenteredLayout classes="px-[24px]">
       <ContainerSecondaryBG>
@@ -101,7 +102,7 @@ export const Details = ({ proposal }: Props) => {
                         proposal!.parsedYAML!.title
                       }`}
                 </div>
-                <LinkOut classes="m-2" href={proposal!.metadata.descriptionURL}>
+                <LinkOut classes="m-2" href={saferDescriptionUrl}>
                   view info
                 </LinkOut>
               </>

--- a/src/features/governance/data/getProposals.ts
+++ b/src/features/governance/data/getProposals.ts
@@ -36,7 +36,7 @@ export const getProposals = async (chainId: number) => {
       ({
         proposalID: proposalID.toString(),
         stage: PROPOSAL_STAGE_KEYS[stages[i]],
-      } as MiniProposal)
+      }) as MiniProposal
   );
 
   const current = proposals.filter((x) => runningProposalStages.has(x.stage));

--- a/src/utils/proposals.ts
+++ b/src/utils/proposals.ts
@@ -42,5 +42,30 @@ export function parsedYAMLFromMarkdown(markdown: string): ParsedYAML | null {
 }
 
 export function getRawGithubUrl(descriptionURL: string) {
-  return descriptionURL.replace('github.com', 'raw.githubusercontent.com').replace('/blob/', '/');
+  return restrictToCeloGovernanceLink(descriptionURL)
+    .replace('github.com', 'raw.githubusercontent.com')
+    .replace('/blob/', '/');
+}
+
+// use governance category of celo forum as fallback url
+const GOVERNANCE_URL_FALLBACK = 'https://forum.celo.org/c/governance/12';
+
+export function restrictToCeloGovernanceLink(descriptionURL: string) {
+  try {
+    // will throw if not a url
+    const strictURL = new URL(descriptionURL);
+    if (
+      strictURL.protocol === 'https:' &&
+      strictURL.host === 'github.com' &&
+      strictURL.pathname.startsWith('/celo-org/governance/blob/main/CGPs/') &&
+      strictURL.pathname.endsWith('.md')
+    ) {
+      return descriptionURL;
+    } else {
+      return GOVERNANCE_URL_FALLBACK;
+    }
+  } catch (e) {
+    // TODO should we have a fallback like to the forum?
+    return GOVERNANCE_URL_FALLBACK;
+  }
 }


### PR DESCRIPTION
### Description

* add x headers to prevent iframing
* restrict `descriptionurl` to only be used if it goes specifically to CGPS in the celo governance repo


### Tested

### Related issues

- Fixes #241 

### Backwards compatibility

will only show proposal urls that direct to the celo governence github repo

### Documentation

