### PR TITLE
Add Github setup files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing
+
+Thank you for your interest in improving the stCelo web app.
+
+If you want to contribute, but aren't sure where to start, you can create a
+[new discussion](https://github.com/celo-org/staked-celo-web-app/discussions).
+
+There are multiple opportunities to contribute. It doesn't matter if you are just
+getting started or are an expert. We appreciate your interest in contributing.
+
+> **IMPORTANT**
+> Please ask before starting work on any significant new features.
+>
+> It's never a fun experience to have your pull request declined after investing time and effort
+> into a new feature. To avoid this from happening, we invite contributors to create a
+> [new discussion](https://github.com/celo-org/staked-celo-web-app/discussions) to discuss API changes or
+> significant new ideas.
+
+## Basic guide
+
+This guide is intended to help you get started with contributing. By following these steps,
+you will understand the development process and workflow.
+
+### Cloning the repository
+
+To start contributing to the project, clone it to your local machine using git:
+
+```sh
+$ git clone https://github.com/celo-org/staked-celo-web-app.git
+```
+
+Navigate to the project's root directory:
+
+```sh
+$ cd staked-celo-web-app
+```
+
+### Installing Node.js
+
+We use [Node.js](https://nodejs.org/en/) to run the project locally.
+
+### Installing dependencies
+
+Once in the project's root directory, run the following command to install the project's 
+dependencies:
+
+```sh
+$ yarn install
+```
+
+After installing the dependencies, the project is ready to be run. 
+
+### Running the web app
+
+Inspect the `package.json` file and look for the `scripts` section. 
+It contains the list of available scripts that can be run.
+
+### Running the test suite 
+
+Run all available tests with:
+
+```sh
+$ yarn run test
+```
+
+When you open a Pull Request, the GitHub CI will run any available test suites for you.
+
+> **INFO**
+> Some tests are run automatically when you open a Pull Request, while others are run when a 
+> maintainer approves the Pull Request. This is for security reasons, as some tests require access 
+> to secrets.
+
+### Open a Pull Request
+
+✅ Now you're ready to contribute!


### PR DESCRIPTION
### Description

- Adds usual CONTRIBUTING file (same as in celo-org/developer-tooling)

### Other changes

None

### Tested

No, only CI. It's a docs change, so I'd expect nothing breaks.

### Related issues

- Fixes #236 

### Backwards compatibility

Yes, only docs change.

### Documentation

Yes