### PR TITLE
fix display vote weight to include both locked and unlocked stcelo

### DIFF
--- a/src/features/governance/components/Details.tsx
+++ b/src/features/governance/components/Details.tsx
@@ -32,8 +32,9 @@ export enum ProposalStage {
 }
 
 export const Details = ({ proposal }: Props) => {
-  const { stCeloBalance, loadBalances, isConnected, address } = useAccountContext();
+  const { loadBalances, isConnected, address } = useAccountContext();
   const {
+    stakedCeloThatCanVoteBalance,
     voteProposal,
     voteProposalStatus,
     getProposalVote,
@@ -131,8 +132,8 @@ export const Details = ({ proposal }: Props) => {
             />
             {currentVote !== undefined && !hasVoted && (
               <TertiaryCallout classes="px-[8px]">
-                {stCeloBalance.displayAsBase()} stCELO will vote {currentVote} for Proposal #
-                {proposal.parsedYAML?.cgp}
+                {stakedCeloThatCanVoteBalance.displayAsBase()} stCELO will vote {currentVote} for
+                Proposal #{proposal.parsedYAML?.cgp}
               </TertiaryCallout>
             )}
             {!hasVoted && (

--- a/src/features/governance/hooks/useVote.ts
+++ b/src/features/governance/hooks/useVote.ts
@@ -262,6 +262,7 @@ export const useVote = () => {
   );
 
   return {
+    stakedCeloThatCanVoteBalance: new StCelo(stakedCeloBalance),
     voteProposal,
     voteProposalStatus,
     getProposalVote,


### PR DESCRIPTION
### Description

when I had locked st celo It would display that 0.00 st celo would vote on a proposal. this is false. as votes are  Locked ST celo + unlocked st celo. 

#### before

<img width="467" alt="Screenshot 2024-08-27 at 8 48 59 PM" src="https://github.com/user-attachments/assets/abbff617-414f-4b3f-9030-340b18172eca">

#### after

<img width="312" alt="Screenshot 2024-08-27 at 8 49 37 PM" src="https://github.com/user-attachments/assets/606807a3-bd4d-41db-9dbd-bf06d4f52301">


### Tested

voted live on actual proposal! 

### Related issues
